### PR TITLE
fix(doc): dead link of documents

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -9,6 +9,8 @@ export default withMermaid(defineConfig({
   srcDir: '.',
   outDir: '.vitepress/dist',
 
+  ignoreDeadLinks: [/^https?:\/\/localhost/],
+
   srcExclude: [
     'README.md',
     'README.zh-CN.md',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,4 +84,4 @@ We follow [Semantic Versioning](https://semver.org/):
 
 ---
 
-For more information, see our [README](README.md).
+For more information, see our [README](https://github.com/alibaba/open-agent-auth#readme).

--- a/docs/api/00-api-overview.md
+++ b/docs/api/00-api-overview.md
@@ -31,9 +31,9 @@ Framework Layer (Developer Interface)
 ## 🔗 Related Resources
 
 - [Quick Start Guide](../guide/01-quick-start.md) — Get started with Open Agent Auth in 5 minutes
-- [User Guide](../guide/02-user-guide.md) — Comprehensive user guide and best practices
-- [Configuration Guide](../guide/03-configuration.md) — Detailed configuration options
-- [Architecture Documentation](../architecture/README.md) — System architecture and design principles
+- [User Guide](../guide/01-quick-start.md) — Comprehensive user guide and best practices
+- [Configuration Guide](../guide/04-configuration.md) — Detailed configuration options
+- [Architecture Documentation](../architecture/) — System architecture and design principles
 
 ---
 

--- a/docs/api/01-role-actor.md
+++ b/docs/api/01-role-actor.md
@@ -656,8 +656,8 @@ resourceServer.logAccess(auditLog);
 - [Framework Layer Overview](00-api-overview.md)
 - [Executor Interfaces Guide](02-aap-executor.md)
 - [Spring Boot Controllers Guide](03-spring-boot-starter.md)
-- [User Guide](../guide/start/00-user-guide.md)
-- [Configuration Guide](../guide/configuration/)
+- [User Guide](../guide/01-quick-start.md)
+- [Configuration Guide](../guide/04-configuration.md)
 
 ---
 

--- a/docs/api/02-aap-executor.md
+++ b/docs/api/02-aap-executor.md
@@ -668,8 +668,8 @@ log.info("Tool executed with authorization: server={}, tool={}", serverName, too
 - [Framework Layer Overview](00-api-overview.md)
 - [Actor Interfaces Guide](01-role-actor.md)
 - [Spring Boot Controllers Guide](03-spring-boot-starter.md)
-- [User Guide](../guide/start/00-user-guide.md)
-- [Configuration Guide](../guide/configuration/)
+- [User Guide](../guide/01-quick-start.md)
+- [Configuration Guide](../guide/04-configuration.md)
 
 ---
 

--- a/docs/api/03-spring-boot-starter.md
+++ b/docs/api/03-spring-boot-starter.md
@@ -768,8 +768,8 @@ public class SecurityLoggingAspect {
 - [Framework Layer Overview](00-api-overview.md)
 - [Actor Interfaces Guide](01-role-actor.md)
 - [Executor Interfaces Guide](02-aap-executor.md)
-- [User Guide](../guide/start/00-user-guide.md)
-- [Configuration Guide](../guide/configuration/)
+- [User Guide](../guide/01-quick-start.md)
+- [Configuration Guide](../guide/04-configuration.md)
 
 ---
 

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -47,9 +47,8 @@ graph LR
 
 ## Related Documentation
 
-- [API Documentation](../api/) — API reference and usage guide
-- [User Guides](../guide/) — Tutorials and getting started
-- [Standards](../standard/) — Protocol standards and specifications
+- [API Documentation](../api/00-api-overview) — API reference and usage guide
+- [User Guides](../guide/01-quick-start) — Tutorials and getting started
 
 ---
 

--- a/docs/guide/01-quick-start.md
+++ b/docs/guide/01-quick-start.md
@@ -759,12 +759,12 @@ open target/site/jacoco-aggregate/index.html
 
 - **Report Issues**: [GitHub Issues](https://github.com/alibaba/open-agent-auth/issues)
 - **Submit Code**: [Pull Request](https://github.com/alibaba/open-agent-auth/pulls)
-- **Contributing Guide**: [CONTRIBUTING.md](../../CONTRIBUTING.md)
+- **Contributing Guide**: [CONTRIBUTING.md](https://github.com/alibaba/open-agent-auth/blob/main/CONTRIBUTING.md)
 
 ### Get Help
 
-- **Documentation**: [Complete Documentation](../../../README.md)
-- **Examples**: [Sample Project](../../open-agent-auth-samples/)
+- **Documentation**: [Complete Documentation](https://github.com/alibaba/open-agent-auth#readme)
+- **Examples**: [Sample Project](https://github.com/alibaba/open-agent-auth/tree/main/open-agent-auth-samples)
 - **Community**: [GitHub Discussions](https://github.com/alibaba/open-agent-auth/discussions)
 - **Email**: open-agent-auth@alibaba-inc.com
 

--- a/docs/guide/06-prompt-protection.md
+++ b/docs/guide/06-prompt-protection.md
@@ -529,8 +529,8 @@ Prompt Protection gives you a comprehensive way to keep sensitive information sa
 
 **Want to learn more?**
 - [Configuration Guide](04-configuration.md)
-- [Security and Audit](../architecture/security/README.md)
-- [Agent Operation Authorization Draft](../standard/draft-liu-agent-operation-authorization-01.txt)
+- [Security and Audit](../architecture/04-security.md)
+- [Agent Operation Authorization Draft](https://datatracker.ietf.org/doc/draft-liu-agent-operation-authorization/)
 
 ---
 
@@ -540,10 +540,10 @@ Prompt Protection gives you a comprehensive way to keep sensitive information sa
 
 - [RFC 7516 - JSON Web Encryption (JWE)](https://www.rfc-editor.org/rfc/rfc7516)
 - [WIMSE Protocol Specification](https://datatracker.ietf.org/doc/draft-ietf-wimse-wimse/)
-- [Agent Operation Authorization Draft](../standard/draft-liu-agent-operation-authorization-01.txt)
+- [Agent Operation Authorization Draft](https://datatracker.ietf.org/doc/draft-liu-agent-operation-authorization/)
 
 ### Related Documentation
 
 - [Configuration Guide](04-configuration.md)
-- [Security and Audit](../architecture/security/README.md)
-- [Identity and Workload Management](../architecture/identity/README.md)
+- [Security and Audit](../architecture/04-security.md)
+- [Identity and Workload Management](../architecture/02-identity.md)


### PR DESCRIPTION
## Description

Fix 25 dead links across documentation files that caused VitePress build failures during GitHub Pages deployment. The dead links fell into three categories:

1. **Broken relative links** — References to non-existent or renamed documentation files (e.g., `../guide/start/00-user-guide`, `../guide/configuration/`, `../architecture/security/README`)
2. **Links to `srcExclude`-ed files** — References to `README.md`, `CONTRIBUTING.md`, and `open-agent-auth-samples/` which are excluded from VitePress builds
3. **Localhost URLs** — Sample service endpoint URLs (`http://localhost:808x`) in documentation tables that VitePress incorrectly validates as dead links

Additionally, configured `actions/configure-pages@v5` with `enablement: true` to auto-enable GitHub Pages for the repository.

## Type of Change
- [x] Bug fix
- [x] Documentation update

## Changes Made

### Dead Link Fixes (9 files, 25 links)

- **`.vitepress/config.mts`** — Added `ignoreDeadLinks: [/^https?:\/\/localhost/]` to skip localhost URL validation; added `enablement: true` for `actions/configure-pages@v5`
- **`docs/architecture/index.md`** — Fixed 3 links: `../api/` → `../api/00-api-overview`, `../guide/` → `../guide/01-quick-start`, removed non-existent `../standard/` link
- **`docs/guide/01-quick-start.md`** — Fixed 3 links: `../../CONTRIBUTING.md`, `../../../README.md`, `../../open-agent-auth-samples/` → GitHub external URLs
- **`docs/api/00-api-overview.md`** — Fixed 3 links: `02-user-guide` → `01-quick-start`, `03-configuration` → `04-configuration`, `../architecture/README` → `../architecture/`
- **`docs/api/01-role-actor.md`** — Fixed 2 links: `start/00-user-guide` → `01-quick-start`, `configuration/` → `04-configuration`
- **`docs/api/02-aap-executor.md`** — Fixed 2 links (same pattern as above)
- **`docs/api/03-spring-boot-starter.md`** — Fixed 2 links (same pattern as above)
- **`CHANGELOG.md`** — Fixed 1 link: `README.md` → GitHub external URL
- **`docs/guide/06-prompt-protection.md`** — Fixed 3 links: `../architecture/security/README` → `../architecture/04-security`, `../architecture/identity/README` → `../architecture/02-identity`

### GitHub Actions Fix

- **`.github/workflows/docs.yml`** — Added `enablement: true` to `actions/configure-pages@v5` to auto-enable GitHub Pages

## Testing
- [x] Manual testing completed
- [x] All existing tests pass

**Test Instructions:**
```bash
# Verify VitePress build passes with no dead link errors
npm run docs:build
```

## Checklist
- [x] Code follows [coding standards](CONTRIBUTING.md#coding-standards)
- [x] Self-review performed
- [x] Documentation updated
- [x] No new warnings
- [x] All tests pass locally

## Breaking Changes
None.

## Additional Context

**Root Cause**: Documentation files referenced paths that either never existed (e.g., `../guide/start/00-user-guide.md`) or were excluded from VitePress via `srcExclude` (e.g., `README.md`, `CONTRIBUTING.md`). The localhost URLs in service endpoint tables were also flagged as dead links by VitePress's link checker.

**Fix Strategy**:
- Broken relative links → corrected to actual file paths
- Links to excluded files (`README.md`, `CONTRIBUTING.md`, samples) → converted to GitHub external URLs
- Localhost URLs → configured VitePress to ignore via regex pattern `[/^https?:\/\/localhost/]`