### PR TITLE
fix: wrong logo link of vitepress

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -52,7 +52,7 @@ export default withMermaid(defineConfig({
   },
 
   themeConfig: {
-    logo: '/public/logo.png',
+    logo: '/logo.png',
     siteTitle: 'Open Agent Auth',
 
     nav: [

--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ hero:
   text: Enterprise-Grade AI Agent Authorization
   tagline: Cryptographic identity binding, fine-grained authorization, and semantic audit trails for AI agents operating on behalf of users.
   image:
-    src: /public/logo.png
+    src: /logo.png
     alt: Open Agent Auth
   actions:
     - theme: brand


### PR DESCRIPTION
## Description

Fix incorrect logo image paths in VitePress configuration and homepage that caused logos not to display on the deployed GitHub Pages site.

In VitePress, files in the `public/` directory are copied to the build output root. References to these files should **not** include the `/public/` prefix. Both the site logo and the homepage hero image were incorrectly referencing `/public/logo.png` instead of `/logo.png`.

## Type of Change
- [x] Bug fix
- [x] Documentation update

## Changes Made

- **`.vitepress/config.mts`** — Fixed site logo path: `'/public/logo.png'` → `'/logo.png'`
- **`index.md`** — Fixed homepage hero image path: `src: /public/logo.png` → `src: /logo.png`

## Testing
- [x] Manual testing completed
- [x] All existing tests pass

**Test Instructions:**
```bash
# Build and verify logo renders correctly
npm run docs:build
npx vitepress preview
# Open browser and verify logo appears in navbar and homepage
```

## Checklist
- [x] Self-review performed
- [x] Documentation updated
- [x] No new warnings
- [x] All tests pass locally

## Breaking Changes
None.

## Additional Context

**Root Cause**: VitePress copies `public/` directory contents to the build output root. When `base: '/open-agent-auth/'` is configured, `themeConfig.logo` automatically prepends the base path. The correct reference for `public/logo.png` is `/logo.png` (which resolves to `/open-agent-auth/logo.png` at runtime), not `/public/logo.png` (which would resolve to `/open-agent-auth/public/logo.png` — a non-existent path).