### PR TITLE
feat(consent): optimize agent operation authorization consent page and render user original input

### DIFF
--- a/open-agent-auth-core/src/main/java/com/alibaba/openagentauth/core/audit/api/OperationTextRenderer.java
+++ b/open-agent-auth-core/src/main/java/com/alibaba/openagentauth/core/audit/api/OperationTextRenderer.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.openagentauth.core.audit.api;
+
+import com.alibaba.openagentauth.core.audit.model.OperationTextRenderContext;
+import com.alibaba.openagentauth.core.audit.model.OperationTextRenderResult;
+
+/**
+ * Strategy interface for rendering human-readable operation text from agent operation proposals.
+ * <p>
+ * According to draft-liu-agent-operation-authorization-01 Section 4, the Authorization Server
+ * generates a {@code renderedText} and {@code renderedOperationText} that describe the authorized
+ * operation in a human-readable format. These texts are included in the
+ * {@code context} and {@code auditTrail} claims of the Agent Operation Authorization Token (AOAT).
+ * </p>
+ * <p>
+ * This interface follows the <b>Strategy Pattern</b> (GoF) to decouple the rendering logic
+ * from the token generation process, enabling multiple rendering strategies:
+ * </p>
+ * <ul>
+ *   <li><b>Pattern-based rendering</b>: Extracts structured information from Rego policies
+ *       and generates text using predefined templates</li>
+ *   <li><b>LLM-based rendering</b>: Uses a large language model to intelligently interpret
+ *       policies and generate natural-language descriptions</li>
+ *   <li><b>Custom rendering</b>: Allows developers to implement their own rendering logic</li>
+ * </ul>
+ * <p>
+ * The rendered text serves the Semantic Audit Trail purposes defined in the specification:
+ * </p>
+ * <ol>
+ *   <li><b>Intent Provenance</b>: Records what the user originally said</li>
+ *   <li><b>Action Interpretation</b>: Documents how the system interpreted the input</li>
+ *   <li><b>Semantic Transparency</b>: Shows whether semantic expansions were applied</li>
+ *   <li><b>User Confirmation Evidence</b>: Provides proof of authorization</li>
+ *   <li><b>Accountability Support</b>: Enables post-hoc analysis</li>
+ * </ol>
+ *
+ * @see <a href="https://datatracker.ietf.org/doc/draft-liu-agent-operation-authorization/">
+ *     draft-liu-agent-operation-authorization-01</a>
+ * @since 1.0
+ */
+@FunctionalInterface
+public interface OperationTextRenderer {
+
+    /**
+     * Renders a human-readable description of the authorized operation.
+     * <p>
+     * This method transforms the operation proposal policy, original user prompt,
+     * and contextual information into a clear, user-friendly text description.
+     * The rendered text is used in both the consent UI (for user review) and
+     * the AOAT (for audit trail purposes).
+     * </p>
+     * <p>
+     * The result includes both the rendered text and the semantic expansion level,
+     * which are required for the {@code auditTrail} claim in the AOAT.
+     * </p>
+     *
+     * @param context the rendering context containing all relevant information
+     * @return the render result containing the text and semantic expansion level, never null
+     */
+    OperationTextRenderResult render(OperationTextRenderContext context);
+
+}

--- a/open-agent-auth-core/src/main/java/com/alibaba/openagentauth/core/audit/impl/PatternBasedOperationTextRenderer.java
+++ b/open-agent-auth-core/src/main/java/com/alibaba/openagentauth/core/audit/impl/PatternBasedOperationTextRenderer.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.openagentauth.core.audit.impl;
+
+import com.alibaba.openagentauth.core.audit.model.OperationTextRenderContext;
+import com.alibaba.openagentauth.core.audit.model.OperationTextRenderResult;
+import com.alibaba.openagentauth.core.audit.model.SemanticExpansionLevel;
+import com.alibaba.openagentauth.core.audit.api.OperationTextRenderer;
+import com.alibaba.openagentauth.core.model.context.OperationRequestContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Pattern-based implementation of {@link OperationTextRenderer}.
+ * <p>
+ * This renderer generates human-readable operation text by extracting structured
+ * information from the rendering context and composing it using predefined patterns.
+ * It serves as the default rendering strategy when no LLM or custom renderer is configured.
+ * </p>
+ * <p>
+ * According to draft-liu-agent-operation-authorization-01, the rendered text should
+ * provide a description like: "Purchase items under $50 during the Nov 11 promotion
+ * (valid until 23:59)"
+ * </p>
+ *
+ * @see OperationTextRenderer
+ * @since 1.0
+ */
+public class PatternBasedOperationTextRenderer implements OperationTextRenderer {
+
+    private static final Logger logger = LoggerFactory.getLogger(PatternBasedOperationTextRenderer.class);
+
+    /**
+     * Maximum number of characters to include from the operation proposal before truncating.
+     * Longer proposals are trimmed and appended with "..." to keep the rendered text concise.
+     */
+    private static final int MAX_POLICY_PREVIEW_LENGTH = 50;
+
+    /**
+     * Formatter for rendering token expiration times in a human-readable "HH:mm" format.
+     */
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This implementation follows a priority-based rendering strategy:
+     * </p>
+     * <ol>
+     *   <li>If the original user prompt is available, renders "Authorized: {prompt}"</li>
+     *   <li>If only the operation proposal is available, renders a truncated policy preview</li>
+     *   <li>Otherwise, renders a generic "Authorized agent operation" fallback</li>
+     * </ol>
+     * <p>
+     * Context information (channel, platform) and token expiration are appended when available.
+     * </p>
+     */
+    @Override
+    public OperationTextRenderResult render(OperationTextRenderContext context) {
+        logger.debug("Rendering operation text using pattern-based strategy");
+
+        StringBuilder rendered = new StringBuilder();
+        SemanticExpansionLevel expansionLevel = SemanticExpansionLevel.NONE;
+
+        String originalPrompt = context.getOriginalPrompt();
+        String operationProposal = context.getOperationProposal();
+
+        if (originalPrompt != null && !originalPrompt.isEmpty()) {
+            rendered.append("Authorized: ").append(originalPrompt);
+            expansionLevel = SemanticExpansionLevel.LOW;
+        } else if (operationProposal != null && !operationProposal.isEmpty()) {
+            String policyPreview = operationProposal.length() > MAX_POLICY_PREVIEW_LENGTH
+                    ? operationProposal.substring(0, MAX_POLICY_PREVIEW_LENGTH) + "..."
+                    : operationProposal;
+            rendered.append("Authorized agent operation per policy: ").append(policyPreview);
+            expansionLevel = SemanticExpansionLevel.LOW;
+        } else {
+            rendered.append("Authorized agent operation");
+        }
+
+        appendContextInfo(rendered, context.getRequestContext());
+        appendExpirationInfo(rendered, context);
+
+        String resultText = rendered.toString();
+        logger.debug("Rendered operation text: {}", resultText);
+        return new OperationTextRenderResult(resultText, expansionLevel);
+    }
+
+    /**
+     * Appends channel and platform information from the request context to the rendered text.
+     * <p>
+     * Adds " via {channel}" and/or " on {platform}" suffixes when the respective values
+     * are present and non-empty.
+     * </p>
+     *
+     * @param rendered the string builder to append to
+     * @param requestContext the request context, may be null
+     */
+    private void appendContextInfo(StringBuilder rendered, OperationRequestContext requestContext) {
+        if (requestContext == null) {
+            return;
+        }
+
+        if (requestContext.getChannel() != null && !requestContext.getChannel().isEmpty()) {
+            rendered.append(" via ").append(requestContext.getChannel());
+        }
+
+        if (requestContext.getAgent() != null && requestContext.getAgent().getPlatform() != null) {
+            rendered.append(" on ").append(requestContext.getAgent().getPlatform());
+        }
+    }
+
+    /**
+     * Appends token expiration information to the rendered text.
+     * <p>
+     * Adds a " (valid until HH:mm)" suffix when the token expiration is set.
+     * The time is formatted in the system's default time zone.
+     * </p>
+     *
+     * @param rendered the string builder to append to
+     * @param context the render context containing the token expiration
+     */
+    private void appendExpirationInfo(StringBuilder rendered, OperationTextRenderContext context) {
+        if (context.getTokenExpiration() == null) {
+            return;
+        }
+
+        String expiresTime = context.getTokenExpiration()
+                .atZone(ZoneId.systemDefault())
+                .format(TIME_FORMATTER);
+        rendered.append(" (valid until ").append(expiresTime).append(")");
+    }
+}

--- a/open-agent-auth-core/src/main/java/com/alibaba/openagentauth/core/audit/model/OperationTextRenderContext.java
+++ b/open-agent-auth-core/src/main/java/com/alibaba/openagentauth/core/audit/model/OperationTextRenderContext.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.openagentauth.core.audit.model;
+
+import com.alibaba.openagentauth.core.audit.api.OperationTextRenderer;
+import com.alibaba.openagentauth.core.model.context.OperationRequestContext;
+import com.alibaba.openagentauth.core.model.evidence.VerifiableCredential;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Immutable context object for operation text rendering.
+ * <p>
+ * This class encapsulates all the information needed by an {@link OperationTextRenderer}
+ * to generate a human-readable description of an authorized operation. It follows the
+ * Parameter Object pattern to avoid long parameter lists and provides a clean API
+ * for rendering strategies.
+ * </p>
+ * <p>
+ * The context includes:
+ * </p>
+ * <ul>
+ *   <li><b>operationProposal</b>: The Rego policy string from the agent's proposal</li>
+ *   <li><b>originalPrompt</b>: The user's original natural-language input (decrypted)</li>
+ *   <li><b>requestContext</b>: Contextual information (channel, agent, user)</li>
+ *   <li><b>verifiedCredential</b>: The verified (and possibly decrypted) evidence VC</li>
+ *   <li><b>tokenExpiration</b>: When the authorization token expires</li>
+ * </ul>
+ *
+ * @see OperationTextRenderer
+ * @since 1.0
+ */
+public class OperationTextRenderContext {
+
+    /**
+     * The Rego policy string from the agent's operation proposal.
+     * Describes the authorized operations in a machine-readable format.
+     */
+    private final String operationProposal;
+
+    /**
+     * The user's original natural-language input (decrypted from the JWT-VC evidence).
+     * Used to provide intent provenance in the audit trail.
+     */
+    private final String originalPrompt;
+
+    /**
+     * Contextual information about the request, including channel, agent, and user details.
+     */
+    private final OperationRequestContext requestContext;
+
+    /**
+     * The verified (and possibly decrypted) Verifiable Credential from the evidence.
+     * Contains the source prompt credential and associated metadata.
+     */
+    private final VerifiableCredential verifiedCredential;
+
+    /**
+     * The expiration time of the authorization token being generated.
+     * Used to include validity period information in the rendered text.
+     */
+    private final Instant tokenExpiration;
+
+    /**
+     * Constructs a new context from the given builder.
+     *
+     * @param builder the builder containing all context values
+     */
+    private OperationTextRenderContext(Builder builder) {
+        this.operationProposal = builder.operationProposal;
+        this.originalPrompt = builder.originalPrompt;
+        this.requestContext = builder.requestContext;
+        this.verifiedCredential = builder.verifiedCredential;
+        this.tokenExpiration = builder.tokenExpiration;
+    }
+
+    /**
+     * Returns the Rego policy string from the agent's operation proposal.
+     *
+     * @return the operation proposal, or null if not set
+     */
+    public String getOperationProposal() {
+        return operationProposal;
+    }
+
+    /**
+     * Returns the user's original natural-language input.
+     *
+     * @return the original prompt, or null if not available
+     */
+    public String getOriginalPrompt() {
+        return originalPrompt;
+    }
+
+    /**
+     * Returns the contextual information about the request.
+     *
+     * @return the request context, or null if not set
+     */
+    public OperationRequestContext getRequestContext() {
+        return requestContext;
+    }
+
+    /**
+     * Returns the verified Verifiable Credential from the evidence.
+     *
+     * @return the verified credential, or null if not available
+     */
+    public VerifiableCredential getVerifiedCredential() {
+        return verifiedCredential;
+    }
+
+    /**
+     * Returns the expiration time of the authorization token.
+     *
+     * @return the token expiration instant, or null if not set
+     */
+    public Instant getTokenExpiration() {
+        return tokenExpiration;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        OperationTextRenderContext that = (OperationTextRenderContext) o;
+        return Objects.equals(operationProposal, that.operationProposal)
+                && Objects.equals(originalPrompt, that.originalPrompt)
+                && Objects.equals(requestContext, that.requestContext)
+                && Objects.equals(verifiedCredential, that.verifiedCredential)
+                && Objects.equals(tokenExpiration, that.tokenExpiration);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(operationProposal, originalPrompt, requestContext,
+                verifiedCredential, tokenExpiration);
+    }
+
+    @Override
+    public String toString() {
+        return "OperationTextRenderContext{" +
+                "operationProposal='" + (operationProposal != null
+                    ? operationProposal.substring(0, Math.min(operationProposal.length(), 50)) + "..."
+                    : "null") + '\'' +
+                ", originalPrompt='" + originalPrompt + '\'' +
+                ", requestContext=" + requestContext +
+                ", tokenExpiration=" + tokenExpiration +
+                '}';
+    }
+
+    /**
+     * Creates a new builder for constructing {@link OperationTextRenderContext} instances.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for constructing {@link OperationTextRenderContext} instances.
+     * <p>
+     * All fields are optional; unset fields default to null.
+     * </p>
+     */
+    public static class Builder {
+
+        private String operationProposal;
+        private String originalPrompt;
+        private OperationRequestContext requestContext;
+        private VerifiableCredential verifiedCredential;
+        private Instant tokenExpiration;
+
+        /**
+         * Sets the Rego policy string from the agent's operation proposal.
+         *
+         * @param operationProposal the operation proposal policy
+         * @return this builder for chaining
+         */
+        public Builder operationProposal(String operationProposal) {
+            this.operationProposal = operationProposal;
+            return this;
+        }
+
+        /**
+         * Sets the user's original natural-language input.
+         *
+         * @param originalPrompt the original user prompt
+         * @return this builder for chaining
+         */
+        public Builder originalPrompt(String originalPrompt) {
+            this.originalPrompt = originalPrompt;
+            return this;
+        }
+
+        /**
+         * Sets the contextual information about the request.
+         *
+         * @param requestContext the request context
+         * @return this builder for chaining
+         */
+        public Builder requestContext(OperationRequestContext requestContext) {
+            this.requestContext = requestContext;
+            return this;
+        }
+
+        /**
+         * Sets the verified Verifiable Credential from the evidence.
+         *
+         * @param verifiedCredential the verified credential
+         * @return this builder for chaining
+         */
+        public Builder verifiedCredential(VerifiableCredential verifiedCredential) {
+            this.verifiedCredential = verifiedCredential;
+            return this;
+        }
+
+        /**
+         * Sets the expiration time of the authorization token.
+         *
+         * @param tokenExpiration the token expiration instant
+         * @return this builder for chaining
+         */
+        public Builder tokenExpiration(Instant tokenExpiration) {
+            this.tokenExpiration = tokenExpiration;
+            return this;
+        }
+
+        /**
+         * Builds a new {@link OperationTextRenderContext} from this builder's values.
+         *
+         * @return a new immutable context instance
+         */
+        public OperationTextRenderContext build() {
+            return new OperationTextRenderContext(this);
+        }
+    }
+}

--- a/open-agent-auth-core/src/main/java/com/alibaba/openagentauth/core/audit/model/OperationTextRenderResult.java
+++ b/open-agent-auth-core/src/main/java/com/alibaba/openagentauth/core/audit/model/OperationTextRenderResult.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.openagentauth.core.audit.model;
+
+import com.alibaba.openagentauth.core.audit.api.OperationTextRenderer;
+
+import java.util.Objects;
+
+/**
+ * Immutable result object returned by {@link OperationTextRenderer}.
+ * <p>
+ * This class encapsulates both the rendered operation text and the semantic expansion
+ * level that was applied during rendering. According to draft-liu-agent-operation-authorization-01,
+ * both pieces of information are required for the {@code auditTrail} claim in the AOAT.
+ * </p>
+ *
+ * @see OperationTextRenderer
+ * @see SemanticExpansionLevel
+ * @since 1.0
+ */
+public class OperationTextRenderResult {
+
+    /**
+     * The human-readable description of the authorized operation.
+     * This text is included in the AOAT's {@code auditTrail.renderedOperationText} claim.
+     */
+    private final String renderedText;
+
+    /**
+     * The level of semantic expansion applied during rendering.
+     * Indicates how much interpretation was added beyond the user's original input.
+     */
+    private final SemanticExpansionLevel semanticExpansionLevel;
+
+    /**
+     * Constructs a new render result with the given text and expansion level.
+     *
+     * @param renderedText the rendered operation text, must not be null
+     * @param semanticExpansionLevel the semantic expansion level applied, must not be null
+     * @throws NullPointerException if either parameter is null
+     */
+    public OperationTextRenderResult(String renderedText, SemanticExpansionLevel semanticExpansionLevel) {
+        this.renderedText = Objects.requireNonNull(renderedText, "renderedText must not be null");
+        this.semanticExpansionLevel = Objects.requireNonNull(semanticExpansionLevel,
+                "semanticExpansionLevel must not be null");
+    }
+
+    /**
+     * Returns the human-readable rendered operation text.
+     *
+     * @return the rendered text, never null
+     */
+    public String getRenderedText() {
+        return renderedText;
+    }
+
+    /**
+     * Returns the semantic expansion level applied during rendering.
+     *
+     * @return the expansion level, never null
+     */
+    public SemanticExpansionLevel getSemanticExpansionLevel() {
+        return semanticExpansionLevel;
+    }
+
+    /**
+     * Creates a result with {@link SemanticExpansionLevel#NONE} expansion.
+     * Use when the rendered text is a direct representation without interpretation.
+     *
+     * @param renderedText the rendered operation text, must not be null
+     * @return a new result with no semantic expansion
+     */
+    public static OperationTextRenderResult withNoExpansion(String renderedText) {
+        return new OperationTextRenderResult(renderedText, SemanticExpansionLevel.NONE);
+    }
+
+    /**
+     * Creates a result with {@link SemanticExpansionLevel#LOW} expansion.
+     * Use when the rendered text includes minor formatting or normalization.
+     *
+     * @param renderedText the rendered operation text, must not be null
+     * @return a new result with low semantic expansion
+     */
+    public static OperationTextRenderResult withLowExpansion(String renderedText) {
+        return new OperationTextRenderResult(renderedText, SemanticExpansionLevel.LOW);
+    }
+
+    /**
+     * Creates a result with {@link SemanticExpansionLevel#MEDIUM} expansion.
+     * Use when the rendered text includes interpretation of ambiguous terms.
+     *
+     * @param renderedText the rendered operation text, must not be null
+     * @return a new result with medium semantic expansion
+     */
+    public static OperationTextRenderResult withMediumExpansion(String renderedText) {
+        return new OperationTextRenderResult(renderedText, SemanticExpansionLevel.MEDIUM);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        OperationTextRenderResult that = (OperationTextRenderResult) o;
+        return Objects.equals(renderedText, that.renderedText)
+                && semanticExpansionLevel == that.semanticExpansionLevel;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(renderedText, semanticExpansionLevel);
+    }
+
+    @Override
+    public String toString() {
+        return "OperationTextRenderResult{" +
+                "renderedText='" + renderedText + '\'' +
+                ", semanticExpansionLevel=" + semanticExpansionLevel +
+                '}';
+    }
+}

--- a/open-agent-auth-core/src/main/java/com/alibaba/openagentauth/core/audit/model/SemanticExpansionLevel.java
+++ b/open-agent-auth-core/src/main/java/com/alibaba/openagentauth/core/audit/model/SemanticExpansionLevel.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.openagentauth.core.audit.model;
+
+/**
+ * Defines the level of semantic expansion applied when rendering operation text.
+ * <p>
+ * According to draft-liu-agent-operation-authorization-01 Section 4 (auditTrail),
+ * the {@code semanticExpansionLevel} field indicates whether semantic expansions
+ * or default values were applied during the rendering process.
+ * </p>
+ *
+ * @see <a href="https://datatracker.ietf.org/doc/draft-liu-agent-operation-authorization/">
+ *     draft-liu-agent-operation-authorization-01</a>
+ * @since 1.0
+ */
+public enum SemanticExpansionLevel {
+
+    /**
+     * No semantic expansion was applied.
+     * The rendered text is a direct representation of the original input without interpretation.
+     */
+    NONE("none"),
+
+    /**
+     * Minimal semantic expansion (basic formatting or normalization).
+     * The rendered text closely mirrors the original input with minor formatting adjustments.
+     */
+    LOW("low"),
+
+    /**
+     * Moderate semantic expansion (interpretation of ambiguous terms).
+     * The rendered text includes some interpretation of the original input to clarify intent.
+     */
+    MEDIUM("medium"),
+
+    /**
+     * Significant semantic expansion (substantial interpretation and additional context).
+     * The rendered text includes substantial interpretation, inferred defaults, or added context
+     * beyond what the user explicitly stated.
+     */
+    HIGH("high");
+
+    /**
+     * The string representation of this expansion level, used in the AOAT {@code auditTrail} claim.
+     */
+    private final String value;
+
+    /**
+     * Constructs a semantic expansion level with the given string value.
+     *
+     * @param value the string representation of this level
+     */
+    SemanticExpansionLevel(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Returns the string representation of this expansion level.
+     *
+     * @return the expansion level value (e.g., "none", "low", "medium", "high")
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Returns the string representation of this expansion level.
+     *
+     * @return the expansion level value
+     */
+    @Override
+    public String toString() {
+        return value;
+    }
+
+}

--- a/open-agent-auth-core/src/main/java/com/alibaba/openagentauth/core/protocol/oauth2/token/aoat/DefaultAoatTokenGenerator.java
+++ b/open-agent-auth-core/src/main/java/com/alibaba/openagentauth/core/protocol/oauth2/token/aoat/DefaultAoatTokenGenerator.java
@@ -38,14 +38,16 @@ import com.alibaba.openagentauth.core.policy.api.PolicyRegistry;
 import com.alibaba.openagentauth.core.protocol.vc.VcVerifier;
 import com.alibaba.openagentauth.core.token.aoat.AoatGenerator;
 import com.alibaba.openagentauth.core.util.ValidationUtils;
+import com.alibaba.openagentauth.core.audit.model.OperationTextRenderContext;
+import com.alibaba.openagentauth.core.audit.model.OperationTextRenderResult;
+import com.alibaba.openagentauth.core.audit.api.OperationTextRenderer;
+import com.alibaba.openagentauth.core.audit.impl.PatternBasedOperationTextRenderer;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jwt.SignedJWT;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -92,12 +94,27 @@ public class DefaultAoatTokenGenerator implements AoatTokenGenerator {
     private final PromptDecryptionService promptDecryptionService;
 
     /**
+     * Strategy for rendering human-readable operation text from agent operation proposals.
+     * <p>
+     * This follows the Strategy Pattern (GoF) to decouple the rendering logic from
+     * the token generation process, enabling pluggable rendering strategies such as
+     * pattern-based, LLM-based, or custom implementations.
+     * </p>
+     *
+     * @see OperationTextRenderer
+     */
+    private final OperationTextRenderer operationTextRenderer;
+
+    /**
      * Default token expiration time in seconds.
      */
     private final long defaultTokenExpirationSeconds;
 
     /**
-     * Creates a new DefaultAoatTokenGenerator.
+     * Creates a new DefaultAoatTokenGenerator with minimal dependencies.
+     * <p>
+     * Uses the default {@link PatternBasedOperationTextRenderer} for rendering operation text.
+     * </p>
      *
      * @param aoatGenerator the AOAT generator
      * @param vcVerifier the VC verifier
@@ -115,21 +132,16 @@ public class DefaultAoatTokenGenerator implements AoatTokenGenerator {
         this.policyRegistry = Objects.requireNonNull(policyRegistry, "Policy registry cannot be null");
         this.bindingInstanceStore = null;
         this.promptDecryptionService = null;
+        this.operationTextRenderer = new PatternBasedOperationTextRenderer();
         this.defaultTokenExpirationSeconds = defaultTokenExpirationSeconds;
         logger.info("DefaultAoatTokenGenerator initialized with expiration: {} seconds", defaultTokenExpirationSeconds);
     }
 
     /**
-     * Creates a new DefaultAoatTokenGenerator with binding instance store.
-     *
-     * @param aoatGenerator the AOAT generator
-     * @param vcVerifier the VC verifier
-     * @param policyRegistry the policy registry
-     * @param bindingInstanceStore the binding instance store
-     * @param defaultTokenExpirationSeconds the default expiration time in seconds
-     */
-    /**
-     * Constructs a new DefaultAoatTokenGenerator.
+     * Constructs a new DefaultAoatTokenGenerator with full dependencies.
+     * <p>
+     * Uses the default {@link PatternBasedOperationTextRenderer} for rendering operation text.
+     * </p>
      *
      * @param aoatGenerator              the AOAT generator
      * @param vcVerifier                 the VC verifier
@@ -147,11 +159,42 @@ public class DefaultAoatTokenGenerator implements AoatTokenGenerator {
             PromptDecryptionService promptDecryptionService,
             long defaultTokenExpirationSeconds
     ) {
+        this(aoatGenerator, vcVerifier, policyRegistry, bindingInstanceStore,
+                promptDecryptionService, new PatternBasedOperationTextRenderer(),
+                defaultTokenExpirationSeconds);
+    }
+
+    /**
+     * Constructs a new DefaultAoatTokenGenerator with a custom {@link OperationTextRenderer}.
+     * <p>
+     * This constructor enables developers to inject their own rendering strategy,
+     * following the Strategy Pattern for maximum flexibility.
+     * </p>
+     *
+     * @param aoatGenerator              the AOAT generator
+     * @param vcVerifier                 the VC verifier
+     * @param policyRegistry             the policy registry
+     * @param bindingInstanceStore       the binding instance store
+     * @param promptDecryptionService    the prompt decryption service for JWE protection (optional)
+     * @param operationTextRenderer      the strategy for rendering operation text
+     * @param defaultTokenExpirationSeconds the default token expiration time in seconds
+     * @throws NullPointerException if any required parameter is null
+     */
+    public DefaultAoatTokenGenerator(
+            AoatGenerator aoatGenerator,
+            VcVerifier vcVerifier,
+            PolicyRegistry policyRegistry,
+            BindingInstanceStore bindingInstanceStore,
+            PromptDecryptionService promptDecryptionService,
+            OperationTextRenderer operationTextRenderer,
+            long defaultTokenExpirationSeconds
+    ) {
         this.aoatGenerator = ValidationUtils.validateNotNull(aoatGenerator, "aoatGenerator");
         this.vcVerifier = ValidationUtils.validateNotNull(vcVerifier, "vcVerifier");
         this.policyRegistry = ValidationUtils.validateNotNull(policyRegistry, "policyRegistry");
         this.bindingInstanceStore = ValidationUtils.validateNotNull(bindingInstanceStore, "bindingInstanceStore");
         this.promptDecryptionService = promptDecryptionService;
+        this.operationTextRenderer = Objects.requireNonNull(operationTextRenderer, "operationTextRenderer must not be null");
         this.defaultTokenExpirationSeconds = defaultTokenExpirationSeconds;
     }
 
@@ -502,6 +545,10 @@ public class DefaultAoatTokenGenerator implements AoatTokenGenerator {
 
     /**
      * Builds TokenAuthorizationContext from PAR claims.
+     * <p>
+     * Delegates the rendering of human-readable operation text to the configured
+     * {@link OperationTextRenderer} strategy, following the Strategy Pattern.
+     * </p>
      *
      * @param parClaims the PAR claims
      * @param verifiedVc the verified (and possibly decrypted) evidence VC
@@ -513,14 +560,14 @@ public class DefaultAoatTokenGenerator implements AoatTokenGenerator {
             return null;
         }
 
-        String renderedText = buildRenderedText(parClaims, verifiedVc);
+        OperationTextRenderResult renderResult = renderOperationText(parClaims, verifiedVc);
         return TokenAuthorizationContext.builder()
-                .renderedText(renderedText)
+                .renderedText(renderResult.getRenderedText())
                 .build();
     }
 
     /**
-     * Builds rendered text for the authorization context.
+     * Renders human-readable operation text using the configured {@link OperationTextRenderer} strategy.
      * <p>
      * According to draft-liu-agent-operation-authorization-01 Section 4, the renderedText
      * should provide a human-readable description of the authorized operation that users
@@ -528,62 +575,31 @@ public class DefaultAoatTokenGenerator implements AoatTokenGenerator {
      * "Purchase items under $50 during the Nov 11 promotion (valid until 23:59)"
      * </p>
      * <p>
-     * This method generates user-friendly rendered text by:
+     * This method constructs an {@link OperationTextRenderContext} from the PAR claims
+     * and delegates the actual rendering to the injected {@link OperationTextRenderer} strategy.
      * </p>
-     * <ul>
-     *   <li>Extracting the original user prompt from the evidence VC (if available)</li>
-     *   <li>Creating a clear, readable description of the authorized operation</li>
-     *   <li>Using a user-friendly time format for expiration</li>
-     * </ul>
      *
      * @param parClaims the PAR claims
      * @param verifiedVc the verified (and possibly decrypted) evidence VC
-     * @return the rendered text
+     * @return the render result containing the text and semantic expansion level
      */
-    private String buildRenderedText(ParJwtClaims parClaims, VerifiableCredential verifiedVc) {
-
-        // Extract operation proposal and context
-        String operationProposal = parClaims.getOperationProposal();
-        OperationRequestContext context = parClaims.getContext();
-
-        // Extract original user prompt from verified (and decrypted) VC for better readability
+    private OperationTextRenderResult renderOperationText(ParJwtClaims parClaims, VerifiableCredential verifiedVc) {
         String originalPrompt = null;
         if (verifiedVc != null && verifiedVc.getCredentialSubject() != null) {
             originalPrompt = verifiedVc.getCredentialSubject().getPrompt();
         }
 
-        StringBuilder rendered = new StringBuilder();
+        Instant tokenExpiration = Instant.now().plusSeconds(defaultTokenExpirationSeconds);
 
-        // Build user-friendly description based on available context
-        if (originalPrompt != null && !originalPrompt.isEmpty()) {
-            // Use original prompt as base for better readability
-            rendered.append("Authorized: ").append(originalPrompt);
-        } else if (!ValidationUtils.isNullOrEmpty(operationProposal)) {
-            // Fallback to generic description if no original prompt available
-            rendered.append("Authorized agent operation per policy: ").append(operationProposal.length() > 50
-                ? operationProposal.substring(0, 50) + "..."
-                : operationProposal);
-        } else {
-            rendered.append("Authorized agent operation");
-        }
+        OperationTextRenderContext renderContext = OperationTextRenderContext.builder()
+                .operationProposal(parClaims.getOperationProposal())
+                .originalPrompt(originalPrompt)
+                .requestContext(parClaims.getContext())
+                .verifiedCredential(verifiedVc)
+                .tokenExpiration(tokenExpiration)
+                .build();
 
-        // Add context information if available
-        if (context != null) {
-            if (context.getChannel() != null && !context.getChannel().isEmpty()) {
-                rendered.append(" via ").append(context.getChannel());
-            }
-            if (context.getAgent() != null && context.getAgent().getPlatform() != null) {
-                rendered.append(" on ").append(context.getAgent().getPlatform());
-            }
-        }
-
-        // Add expiration time in user-friendly format
-        Instant expires = Instant.now().plusSeconds(defaultTokenExpirationSeconds);
-        String expiresTime = expires.atZone(ZoneId.systemDefault())
-                .format(DateTimeFormatter.ofPattern("HH:mm"));
-        rendered.append(" (valid until ").append(expiresTime).append(")");
-
-        return rendered.toString();
+        return operationTextRenderer.render(renderContext);
     }
 
     /**
@@ -652,29 +668,32 @@ public class DefaultAoatTokenGenerator implements AoatTokenGenerator {
 
     /**
      * Builds AuditTrail from PAR claims and verified VC.
+     * <p>
+     * According to draft-liu-agent-operation-authorization-01 Section 4, the auditTrail
+     * establishes a complete, semantically traceable chain from the user's original intent
+     * to the system's final executed action. The semantic expansion level is determined
+     * by the configured {@link OperationTextRenderer} strategy.
+     * </p>
      *
      * @param parClaims the PAR claims
      * @param verifiedVc the verified VerifiableCredential (may be null)
      * @return the built AuditTrail
      */
     private AuditTrail buildAuditTrail(ParJwtClaims parClaims, VerifiableCredential verifiedVc) {
-
         String originalPromptText = null;
         if (verifiedVc != null && verifiedVc.getCredentialSubject() != null) {
             originalPromptText = verifiedVc.getCredentialSubject().getPrompt();
         }
 
-        String renderedOperationText = buildRenderedText(parClaims, verifiedVc);
-        String semanticExpansionLevel = "low";
+        OperationTextRenderResult renderResult = renderOperationText(parClaims, verifiedVc);
         String userAcknowledgeTimestamp = Instant.now().toString();
-        String consentInterfaceVersion = "1.0";
 
         return AuditTrail.builder()
                 .originalPromptText(originalPromptText)
-                .renderedOperationText(renderedOperationText)
-                .semanticExpansionLevel(semanticExpansionLevel)
+                .renderedOperationText(renderResult.getRenderedText())
+                .semanticExpansionLevel(renderResult.getSemanticExpansionLevel().getValue())
                 .userAcknowledgeTimestamp(userAcknowledgeTimestamp)
-                .consentInterfaceVersion(consentInterfaceVersion)
+                .consentInterfaceVersion("1.0")
                 .build();
     }
 

--- a/open-agent-auth-core/src/test/java/com/alibaba/openagentauth/core/audit/impl/PatternBasedOperationTextRendererTest.java
+++ b/open-agent-auth-core/src/test/java/com/alibaba/openagentauth/core/audit/impl/PatternBasedOperationTextRendererTest.java
@@ -1,0 +1,957 @@
+/*
+ * Copyright 2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.openagentauth.core.audit.impl;
+
+import com.alibaba.openagentauth.core.audit.model.OperationTextRenderContext;
+import com.alibaba.openagentauth.core.audit.model.OperationTextRenderResult;
+import com.alibaba.openagentauth.core.audit.model.SemanticExpansionLevel;
+import com.alibaba.openagentauth.core.model.context.OperationRequestContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Comprehensive unit tests for {@link PatternBasedOperationTextRenderer}.
+ * <p>
+ * Tests cover all rendering scenarios including:
+ * - Original prompt rendering
+ * - Operation proposal rendering with truncation
+ * - Fallback rendering when both are absent
+ * - Channel and platform information appending
+ * - Token expiration formatting
+ * - Semantic expansion level assignment
+ * </p>
+ */
+@DisplayName("PatternBasedOperationTextRenderer Tests")
+class PatternBasedOperationTextRendererTest {
+
+    private final PatternBasedOperationTextRenderer renderer = new PatternBasedOperationTextRenderer();
+
+    @Nested
+    @DisplayName("Original Prompt Rendering")
+    class OriginalPromptRendering {
+
+        @Test
+        @DisplayName("Should render with original prompt and LOW expansion level")
+        void shouldRenderWithOriginalPrompt() {
+            OperationRequestContext requestContext = OperationRequestContext.builder()
+                    .channel("web")
+                    .agent(new OperationRequestContext.AgentContext(null, "slack", null))
+                    .build();
+
+            Instant expiration = ZonedDateTime.of(2026, 3, 7, 23, 59, 0, 0, ZoneId.systemDefault())
+                    .toInstant();
+
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .originalPrompt("Purchase items under $50 during the Nov 11 promotion")
+                    .requestContext(requestContext)
+                    .tokenExpiration(expiration)
+                    .build();
+
+            OperationTextRenderResult result = renderer.render(context);
+
+            assertThat(result.getRenderedText())
+                    .isEqualTo("Authorized: Purchase items under $50 during the Nov 11 promotion via web on slack (valid until 23:59)");
+            assertThat(result.getSemanticExpansionLevel()).isEqualTo(SemanticExpansionLevel.LOW);
+        }
+
+        @Test
+        @DisplayName("Should render with empty original prompt and use operation proposal")
+        void shouldUseOperationProposalWhenOriginalPromptIsEmpty() {
+            OperationRequestContext requestContext = OperationRequestContext.builder()
+                    .channel("mobile")
+                    .build();
+
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .originalPrompt("")
+                    .operationProposal("allow read access to user profile")
+                    .requestContext(requestContext)
+                    .build();
+
+            OperationTextRenderResult result = renderer.render(context);
+
+            assertThat(result.getRenderedText())
+                    .isEqualTo("Authorized agent operation per policy: allow read access to user profile via mobile");
+            assertThat(result.getSemanticExpansionLevel()).isEqualTo(SemanticExpansionLevel.LOW);
+        }
+    }
+
+    @Nested
+    @DisplayName("Operation Proposal Rendering")
+    class OperationProposalRendering {
+
+        @Test
+        @DisplayName("Should render with operation proposal when original prompt is null")
+        void shouldRenderWithOperationProposal() {
+            OperationRequestContext requestContext = OperationRequestContext.builder()
+                    .agent(new OperationRequestContext.AgentContext(null, "teams", null))
+                    .build();
+
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .operationProposal("allow write access to documents")
+                    .requestContext(requestContext)
+                    .build();
+
+            OperationTextRenderResult result = renderer.render(context);
+
+            assertThat(result.getRenderedText())
+                    .isEqualTo("Authorized agent operation per policy: allow write access to documents on teams");
+            assertThat(result.getSemanticExpansionLevel()).isEqualTo(SemanticExpansionLevel.LOW);
+        }
+
+        @Test
+        @DisplayName("Should truncate operation proposal when exceeding 50 characters")
+        void shouldTruncateLongOperationProposal() {
+            String longProposal = "This is a very long operation proposal that definitely exceeds the fifty character limit";
+            assertThat(longProposal.length()).isGreaterThan(50);
+
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .operationProposal(longProposal)
+                    .build();
+
+            OperationTextRenderResult result = renderer.render(context);
+
+            assertThat(result.getRenderedText())
+                    .isEqualTo("Authorized agent operation per policy: This is a very long operation proposal that defini...");
+            assertThat(result.getSemanticExpansionLevel()).isEqualTo(SemanticExpansionLevel.LOW);
+        }
+
+        @Test
+        @DisplayName("Should render exactly 50 characters without truncation")
+        void shouldRenderExactFiftyCharactersWithoutTruncation() {
+            String exactFiftyProposal = "12345678901234567890123456789012345678901234567890";
+            assertThat(exactFiftyProposal.length()).isEqualTo(50);
+
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .operationProposal(exactFiftyProposal)
+                    .build();
+
+            OperationTextRenderResult result = renderer.render(context);
+
+            assertThat(result.getRenderedText())
+                    .isEqualTo("Authorized agent operation per policy: " + exactFiftyProposal);
+            assertThat(result.getRenderedText()).doesNotContain("...");
+        }
+
+        @Test
+        @DisplayName("Should render with empty operation proposal and use fallback")
+        void shouldUseFallbackWhenOperationProposalIsEmpty() {
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .operationProposal("")
+                    .build();
+
+            OperationTextRenderResult result = renderer.render(context);
+
+            assertThat(result.getRenderedText())
+                    .isEqualTo("Authorized agent operation");
+            assertThat(result.getSemanticExpansionLevel()).isEqualTo(SemanticExpansionLevel.NONE);
+        }
+    }
+
+    @Nested
+    @DisplayName("Fallback Rendering")
+    class FallbackRendering {
+
+        @Test
+        @DisplayName("Should render fallback message when both prompt and proposal are null")
+        void shouldRenderFallbackWhenBothAreNull() {
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .build();
+
+            OperationTextRenderResult result = renderer.render(context);
+
+            assertThat(result.getRenderedText()).isEqualTo("Authorized agent operation");
+            assertThat(result.getSemanticExpansionLevel()).isEqualTo(SemanticExpansionLevel.NONE);
+        }
+
+        @Test
+        @DisplayName("Should render fallback message when both prompt and proposal are empty")
+        void shouldRenderFallbackWhenBothAreEmpty() {
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .originalPrompt("")
+                    .operationProposal("")
+                    .build();
+
+            OperationTextRenderResult result = renderer.render(context);
+
+            assertThat(result.getRenderedText()).isEqualTo("Authorized agent operation");
+            assertThat(result.getSemanticExpansionLevel()).isEqualTo(SemanticExpansionLevel.NONE);
+        }
+    }
+
+    @Nested
+    @DisplayName("Context Information Appending")
+    class ContextInformationAppending {
+
+        @Test
+        @DisplayName("Should append channel information when present")
+        void shouldAppendChannelInformation() {
+            OperationRequestContext requestContext = OperationRequestContext.builder()
+                    .channel("web")
+                    .build();
+
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .originalPrompt("Test prompt")
+                    .requestContext(requestContext)
+                    .build();
+
+            OperationTextRenderResult result = renderer.render(context);
+
+            assertThat(result.getRenderedText()).contains(" via web");
+        }
+
+        @Test
+        @DisplayName("Should append platform information when present")
+        void shouldAppendPlatformInformation() {
+            OperationRequestContext requestContext = OperationRequestContext.builder()
+                    .agent(new OperationRequestContext.AgentContext(null, "slack", null))
+                    .build();
+
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .originalPrompt("Test prompt")
+                    .requestContext(requestContext)
+                    .build();
+
+            OperationTextRenderResult result = renderer.render(context);
+
+            assertThat(result.getRenderedText()).contains(" on slack");
+        }
+
+        @Test
+        @DisplayName("Should append both channel and platform when both are present")
+        void shouldAppendBothChannelAndPlatform() {
+            OperationRequestContext requestContext = OperationRequestContext.builder()
+                    .channel("mobile")
+                    .agent(new OperationRequestContext.AgentContext(null, "discord", null))
+                    .build();
+
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .originalPrompt("Test prompt")
+                    .requestContext(requestContext)
+                    .build();
+
+            OperationTextRenderResult result = renderer.render(context);
+
+            assertThat(result.getRenderedText()).contains(" via mobile").contains(" on discord");
+        }
+
+        @Test
+        @DisplayName("Should not append channel when it is null")
+        void shouldNotAppendChannelWhenNull() {
+            OperationRequestContext requestContext = OperationRequestContext.builder()
+                    .build();
+
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .originalPrompt("Test prompt")
+                    .requestContext(requestContext)
+                    .build();
+
+            OperationTextRenderResult result = renderer.render(context);
+
+            assertThat(result.getRenderedText()).doesNotContain(" via ");
+        }
+
+        @Test
+        @DisplayName("Should not append channel when it is empty")
+        void shouldNotAppendChannelWhenEmpty() {
+            OperationRequestContext requestContext = OperationRequestContext.builder()
+                    .channel("")
+                    .build();
+
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .originalPrompt("Test prompt")
+                    .requestContext(requestContext)
+                    .build();
+
+            OperationTextRenderResult result = renderer.render(context);
+
+            assertThat(result.getRenderedText()).doesNotContain(" via ");
+        }
+
+        @Test
+        @DisplayName("Should not append platform when agent is null")
+        void shouldNotAppendPlatformWhenAgentIsNull() {
+            OperationRequestContext requestContext = OperationRequestContext.builder()
+                    .build();
+
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .originalPrompt("Test prompt")
+                    .requestContext(requestContext)
+                    .build();
+
+            OperationTextRenderResult result = renderer.render(context);
+
+            assertThat(result.getRenderedText()).doesNotContain(" on ");
+        }
+
+        @Test
+        @DisplayName("Should not append platform when platform is null")
+        void shouldNotAppendPlatformWhenPlatformIsNull() {
+            OperationRequestContext requestContext = OperationRequestContext.builder()
+                    .agent(new OperationRequestContext.AgentContext(null, null, null))
+                    .build();
+
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .originalPrompt("Test prompt")
+                    .requestContext(requestContext)
+                    .build();
+
+            OperationTextRenderResult result = renderer.render(context);
+
+            assertThat(result.getRenderedText()).doesNotContain(" on ");
+        }
+
+        @Test
+        @DisplayName("Should not append context information when requestContext is null")
+        void shouldNotAppendContextWhenRequestContextIsNull() {
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .originalPrompt("Test prompt")
+                    .build();
+
+            OperationTextRenderResult result = renderer.render(context);
+
+            assertThat(result.getRenderedText())
+                    .isEqualTo("Authorized: Test prompt");
+            assertThat(result.getRenderedText()).doesNotContain(" via ").doesNotContain(" on ");
+        }
+    }
+
+    @Nested
+    @DisplayName("Token Expiration Formatting")
+    class TokenExpirationFormatting {
+
+        @Test
+        @DisplayName("Should append expiration time in HH:mm format")
+        void shouldAppendExpirationTime() {
+            Instant expiration = ZonedDateTime.of(2026, 3, 7, 15, 30, 0, 0, ZoneId.systemDefault())
+                    .toInstant();
+
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .originalPrompt("Test prompt")
+                    .tokenExpiration(expiration)
+                    .build();
+
+            OperationTextRenderResult result = renderer.render(context);
+
+            assertThat(result.getRenderedText()).contains("(valid until 15:30)");
+        }
+
+        @Test
+        @DisplayName("Should format midnight correctly")
+        void shouldFormatMidnightCorrectly() {
+            Instant expiration = ZonedDateTime.of(2026, 3, 7, 0, 0, 0, 0, ZoneId.systemDefault())
+                    .toInstant();
+
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .originalPrompt("Test prompt")
+                    .tokenExpiration(expiration)
+                    .build();
+
+            OperationTextRenderResult result = renderer.render(context);
+
+            assertThat(result.getRenderedText()).contains("(valid until 00:00)");
+        }
+
+        @Test
+        @DisplayName("Should format 23:59 correctly")
+        void shouldFormatEndOfDayCorrectly() {
+            Instant expiration = ZonedDateTime.of(2026, 3, 7, 23, 59, 0, 0, ZoneId.systemDefault())
+                    .toInstant();
+
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .originalPrompt("Test prompt")
+                    .tokenExpiration(expiration)
+                    .build();
+
+            OperationTextRenderResult result = renderer.render(context);
+
+            assertThat(result.getRenderedText()).contains("(valid until 23:59)");
+        }
+
+        @Test
+        @DisplayName("Should not append expiration when tokenExpiration is null")
+        void shouldNotAppendExpirationWhenNull() {
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .originalPrompt("Test prompt")
+                    .build();
+
+            OperationTextRenderResult result = renderer.render(context);
+
+            assertThat(result.getRenderedText()).doesNotContain("(valid until");
+        }
+    }
+
+    @Nested
+    @DisplayName("Semantic Expansion Level Assignment")
+    class SemanticExpansionLevelAssignment {
+
+        @Test
+        @DisplayName("Should assign NONE expansion level for fallback rendering")
+        void shouldAssignNoneExpansionForFallback() {
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .build();
+
+            OperationTextRenderResult result = renderer.render(context);
+
+            assertThat(result.getSemanticExpansionLevel()).isEqualTo(SemanticExpansionLevel.NONE);
+        }
+
+        @Test
+        @DisplayName("Should assign LOW expansion level when original prompt is present")
+        void shouldAssignLowExpansionForOriginalPrompt() {
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .originalPrompt("Test prompt")
+                    .build();
+
+            OperationTextRenderResult result = renderer.render(context);
+
+            assertThat(result.getSemanticExpansionLevel()).isEqualTo(SemanticExpansionLevel.LOW);
+        }
+
+        @Test
+        @DisplayName("Should assign LOW expansion level when operation proposal is present")
+        void shouldAssignLowExpansionForOperationProposal() {
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .operationProposal("allow read access")
+                    .build();
+
+            OperationTextRenderResult result = renderer.render(context);
+
+            assertThat(result.getSemanticExpansionLevel()).isEqualTo(SemanticExpansionLevel.LOW);
+        }
+
+        @Test
+        @DisplayName("Should assign LOW expansion level even when proposal is truncated")
+        void shouldAssignLowExpansionForTruncatedProposal() {
+            String longProposal = "This is a very long operation proposal that definitely exceeds the fifty character limit";
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .operationProposal(longProposal)
+                    .build();
+
+            OperationTextRenderResult result = renderer.render(context);
+
+            assertThat(result.getSemanticExpansionLevel()).isEqualTo(SemanticExpansionLevel.LOW);
+        }
+    }
+
+    @Nested
+    @DisplayName("OperationTextRenderResult Equality")
+    class OperationTextRenderResultEquality {
+
+        @Test
+        @DisplayName("Should be equal when both text and expansion level match")
+        void shouldBeEqualWhenBothMatch() {
+            OperationTextRenderResult result1 = new OperationTextRenderResult("Test text", SemanticExpansionLevel.LOW);
+            OperationTextRenderResult result2 = new OperationTextRenderResult("Test text", SemanticExpansionLevel.LOW);
+
+            assertThat(result1).isEqualTo(result2);
+            assertThat(result1.hashCode()).isEqualTo(result2.hashCode());
+        }
+
+        @Test
+        @DisplayName("Should not be equal when text differs")
+        void shouldNotBeEqualWhenTextDiffers() {
+            OperationTextRenderResult result1 = new OperationTextRenderResult("Text 1", SemanticExpansionLevel.LOW);
+            OperationTextRenderResult result2 = new OperationTextRenderResult("Text 2", SemanticExpansionLevel.LOW);
+
+            assertThat(result1).isNotEqualTo(result2);
+        }
+
+        @Test
+        @DisplayName("Should not be equal when expansion level differs")
+        void shouldNotBeEqualWhenExpansionLevelDiffers() {
+            OperationTextRenderResult result1 = new OperationTextRenderResult("Test text", SemanticExpansionLevel.NONE);
+            OperationTextRenderResult result2 = new OperationTextRenderResult("Test text", SemanticExpansionLevel.LOW);
+
+            assertThat(result1).isNotEqualTo(result2);
+        }
+
+        @Test
+        @DisplayName("Should be reflexive")
+        void shouldBeReflexive() {
+            OperationTextRenderResult result = new OperationTextRenderResult("Test text", SemanticExpansionLevel.LOW);
+
+            assertThat(result).isEqualTo(result);
+        }
+
+        @Test
+        @DisplayName("Should be symmetric")
+        void shouldBeSymmetric() {
+            OperationTextRenderResult result1 = new OperationTextRenderResult("Test text", SemanticExpansionLevel.LOW);
+            OperationTextRenderResult result2 = new OperationTextRenderResult("Test text", SemanticExpansionLevel.LOW);
+
+            assertThat(result1.equals(result2)).isEqualTo(result2.equals(result1));
+        }
+
+        @Test
+        @DisplayName("Should be transitive")
+        void shouldBeTransitive() {
+            OperationTextRenderResult result1 = new OperationTextRenderResult("Test text", SemanticExpansionLevel.LOW);
+            OperationTextRenderResult result2 = new OperationTextRenderResult("Test text", SemanticExpansionLevel.LOW);
+            OperationTextRenderResult result3 = new OperationTextRenderResult("Test text", SemanticExpansionLevel.LOW);
+
+            assertThat(result1.equals(result2) && result2.equals(result3) && result1.equals(result3)).isTrue();
+        }
+
+        @Test
+        @DisplayName("Should not be equal to null")
+        void shouldNotBeEqualToNull() {
+            OperationTextRenderResult result = new OperationTextRenderResult("Test text", SemanticExpansionLevel.LOW);
+
+            assertThat(result).isNotEqualTo(null);
+        }
+
+        @Test
+        @DisplayName("Should not be equal to different type")
+        void shouldNotBeEqualToDifferentType() {
+            OperationTextRenderResult result = new OperationTextRenderResult("Test text", SemanticExpansionLevel.LOW);
+
+            assertThat(result).isNotEqualTo("Test text");
+        }
+
+        @Test
+        @DisplayName("Should have consistent hashCode")
+        void shouldHaveConsistentHashCode() {
+            OperationTextRenderResult result = new OperationTextRenderResult("Test text", SemanticExpansionLevel.LOW);
+
+            int hashCode1 = result.hashCode();
+            int hashCode2 = result.hashCode();
+
+            assertThat(hashCode1).isEqualTo(hashCode2);
+        }
+    }
+
+    @Nested
+    @DisplayName("OperationTextRenderContext Builder")
+    class OperationTextRenderContextBuilder {
+
+        @Test
+        @DisplayName("Should build context with all fields")
+        void shouldBuildContextWithAllFields() {
+            OperationRequestContext requestContext = OperationRequestContext.builder()
+                    .channel("web")
+                    .agent(new OperationRequestContext.AgentContext(null, "slack", null))
+                    .build();
+
+            Instant expiration = Instant.now();
+
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .operationProposal("allow read access")
+                    .originalPrompt("Read user profile")
+                    .requestContext(requestContext)
+                    .tokenExpiration(expiration)
+                    .build();
+
+            assertThat(context.getOperationProposal()).isEqualTo("allow read access");
+            assertThat(context.getOriginalPrompt()).isEqualTo("Read user profile");
+            assertThat(context.getRequestContext()).isEqualTo(requestContext);
+            assertThat(context.getTokenExpiration()).isEqualTo(expiration);
+        }
+
+        @Test
+        @DisplayName("Should build context with only required fields")
+        void shouldBuildContextWithOnlyRequiredFields() {
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .build();
+
+            assertThat(context.getOperationProposal()).isNull();
+            assertThat(context.getOriginalPrompt()).isNull();
+            assertThat(context.getRequestContext()).isNull();
+            assertThat(context.getVerifiedCredential()).isNull();
+            assertThat(context.getTokenExpiration()).isNull();
+        }
+
+        @Test
+        @DisplayName("Should build context with single field")
+        void shouldBuildContextWithSingleField() {
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .originalPrompt("Test prompt")
+                    .build();
+
+            assertThat(context.getOriginalPrompt()).isEqualTo("Test prompt");
+            assertThat(context.getOperationProposal()).isNull();
+            assertThat(context.getRequestContext()).isNull();
+        }
+
+        @Test
+        @DisplayName("Should support builder chaining")
+        void shouldSupportBuilderChaining() {
+            OperationRequestContext requestContext = OperationRequestContext.builder()
+                    .channel("web")
+                    .build();
+
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .operationProposal("allow read access")
+                    .originalPrompt("Read user profile")
+                    .requestContext(requestContext)
+                    .build();
+
+            assertThat(context.getOperationProposal()).isEqualTo("allow read access");
+            assertThat(context.getOriginalPrompt()).isEqualTo("Read user profile");
+            assertThat(context.getRequestContext()).isEqualTo(requestContext);
+        }
+
+        @Test
+        @DisplayName("Should create independent instances from same builder")
+        void shouldCreateIndependentInstances() {
+            OperationRequestContext requestContext = OperationRequestContext.builder()
+                    .channel("web")
+                    .build();
+
+            OperationTextRenderContext.Builder builder = OperationTextRenderContext.builder()
+                    .operationProposal("allow read access");
+
+            OperationTextRenderContext context1 = builder.originalPrompt("Prompt 1").build();
+            OperationTextRenderContext context2 = builder.originalPrompt("Prompt 2").build();
+
+            assertThat(context1.getOriginalPrompt()).isEqualTo("Prompt 1");
+            assertThat(context2.getOriginalPrompt()).isEqualTo("Prompt 2");
+            assertThat(context1.getOperationProposal()).isEqualTo(context2.getOperationProposal());
+        }
+    }
+
+    @Nested
+    @DisplayName("Integration Tests")
+    class IntegrationTests {
+
+        @Test
+        @DisplayName("Should render complete scenario with all components")
+        void shouldRenderCompleteScenario() {
+            OperationRequestContext requestContext = OperationRequestContext.builder()
+                    .channel("web")
+                    .agent(new OperationRequestContext.AgentContext(null, "slack", null))
+                    .build();
+
+            Instant expiration = ZonedDateTime.of(2026, 3, 7, 23, 59, 0, 0, ZoneId.systemDefault())
+                    .toInstant();
+
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .originalPrompt("Purchase items under $50 during the Nov 11 promotion")
+                    .requestContext(requestContext)
+                    .tokenExpiration(expiration)
+                    .build();
+
+            OperationTextRenderResult result = renderer.render(context);
+
+            assertThat(result.getRenderedText())
+                    .isEqualTo("Authorized: Purchase items under $50 during the Nov 11 promotion via web on slack (valid until 23:59)");
+            assertThat(result.getSemanticExpansionLevel()).isEqualTo(SemanticExpansionLevel.LOW);
+        }
+
+        @Test
+        @DisplayName("Should render scenario with truncated proposal and all context")
+        void shouldRenderWithTruncatedProposalAndAllContext() {
+            String longProposal = "This is a very long operation proposal that definitely exceeds the fifty character limit for testing purposes";
+            OperationRequestContext requestContext = OperationRequestContext.builder()
+                    .channel("mobile")
+                    .agent(new OperationRequestContext.AgentContext(null, "discord", null))
+                    .build();
+
+            Instant expiration = ZonedDateTime.of(2026, 3, 7, 18, 30, 0, 0, ZoneId.systemDefault())
+                    .toInstant();
+
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .operationProposal(longProposal)
+                    .requestContext(requestContext)
+                    .tokenExpiration(expiration)
+                    .build();
+
+            OperationTextRenderResult result = renderer.render(context);
+
+            assertThat(result.getRenderedText())
+                    .isEqualTo("Authorized agent operation per policy: This is a very long operation proposal that defini... via mobile on discord (valid until 18:30)");
+            assertThat(result.getSemanticExpansionLevel()).isEqualTo(SemanticExpansionLevel.LOW);
+        }
+
+        @Test
+        @DisplayName("Should render minimal scenario with only fallback")
+        void shouldRenderMinimalScenario() {
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .build();
+
+            OperationTextRenderResult result = renderer.render(context);
+
+            assertThat(result.getRenderedText()).isEqualTo("Authorized agent operation");
+            assertThat(result.getSemanticExpansionLevel()).isEqualTo(SemanticExpansionLevel.NONE);
+        }
+    }
+
+    @Nested
+    @DisplayName("SemanticExpansionLevel Enum")
+    class SemanticExpansionLevelTests {
+
+        @Test
+        @DisplayName("Should have correct string values for all levels")
+        void shouldHaveCorrectStringValues() {
+            assertThat(SemanticExpansionLevel.NONE.getValue()).isEqualTo("none");
+            assertThat(SemanticExpansionLevel.LOW.getValue()).isEqualTo("low");
+            assertThat(SemanticExpansionLevel.MEDIUM.getValue()).isEqualTo("medium");
+            assertThat(SemanticExpansionLevel.HIGH.getValue()).isEqualTo("high");
+        }
+
+        @Test
+        @DisplayName("Should return value from toString")
+        void shouldReturnValueFromToString() {
+            assertThat(SemanticExpansionLevel.NONE.toString()).isEqualTo("none");
+            assertThat(SemanticExpansionLevel.LOW.toString()).isEqualTo("low");
+            assertThat(SemanticExpansionLevel.MEDIUM.toString()).isEqualTo("medium");
+            assertThat(SemanticExpansionLevel.HIGH.toString()).isEqualTo("high");
+        }
+
+        @Test
+        @DisplayName("Should have exactly four enum constants")
+        void shouldHaveFourEnumConstants() {
+            assertThat(SemanticExpansionLevel.values()).hasSize(4);
+        }
+
+        @Test
+        @DisplayName("Should resolve from name via valueOf")
+        void shouldResolveFromNameViaValueOf() {
+            assertThat(SemanticExpansionLevel.valueOf("NONE")).isEqualTo(SemanticExpansionLevel.NONE);
+            assertThat(SemanticExpansionLevel.valueOf("LOW")).isEqualTo(SemanticExpansionLevel.LOW);
+            assertThat(SemanticExpansionLevel.valueOf("MEDIUM")).isEqualTo(SemanticExpansionLevel.MEDIUM);
+            assertThat(SemanticExpansionLevel.valueOf("HIGH")).isEqualTo(SemanticExpansionLevel.HIGH);
+        }
+
+        @Test
+        @DisplayName("Should throw IllegalArgumentException for invalid name")
+        void shouldThrowForInvalidName() {
+            assertThatThrownBy(() -> SemanticExpansionLevel.valueOf("INVALID"))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("OperationTextRenderResult Static Factories and Validation")
+    class OperationTextRenderResultFactories {
+
+        @Test
+        @DisplayName("withNoExpansion should create result with NONE level")
+        void withNoExpansionShouldCreateResultWithNoneLevel() {
+            OperationTextRenderResult result = OperationTextRenderResult.withNoExpansion("Test text");
+
+            assertThat(result.getRenderedText()).isEqualTo("Test text");
+            assertThat(result.getSemanticExpansionLevel()).isEqualTo(SemanticExpansionLevel.NONE);
+        }
+
+        @Test
+        @DisplayName("withLowExpansion should create result with LOW level")
+        void withLowExpansionShouldCreateResultWithLowLevel() {
+            OperationTextRenderResult result = OperationTextRenderResult.withLowExpansion("Test text");
+
+            assertThat(result.getRenderedText()).isEqualTo("Test text");
+            assertThat(result.getSemanticExpansionLevel()).isEqualTo(SemanticExpansionLevel.LOW);
+        }
+
+        @Test
+        @DisplayName("withMediumExpansion should create result with MEDIUM level")
+        void withMediumExpansionShouldCreateResultWithMediumLevel() {
+            OperationTextRenderResult result = OperationTextRenderResult.withMediumExpansion("Test text");
+
+            assertThat(result.getRenderedText()).isEqualTo("Test text");
+            assertThat(result.getSemanticExpansionLevel()).isEqualTo(SemanticExpansionLevel.MEDIUM);
+        }
+
+        @Test
+        @DisplayName("Should throw NullPointerException when renderedText is null")
+        void shouldThrowWhenRenderedTextIsNull() {
+            assertThatThrownBy(() -> new OperationTextRenderResult(null, SemanticExpansionLevel.LOW))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("renderedText");
+        }
+
+        @Test
+        @DisplayName("Should throw NullPointerException when semanticExpansionLevel is null")
+        void shouldThrowWhenSemanticExpansionLevelIsNull() {
+            assertThatThrownBy(() -> new OperationTextRenderResult("text", null))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("semanticExpansionLevel");
+        }
+
+        @Test
+        @DisplayName("toString should contain rendered text and expansion level")
+        void toStringShouldContainRenderedTextAndExpansionLevel() {
+            OperationTextRenderResult result = new OperationTextRenderResult("Test text", SemanticExpansionLevel.LOW);
+
+            String stringRepresentation = result.toString();
+
+            assertThat(stringRepresentation).contains("Test text");
+            assertThat(stringRepresentation).contains("low");
+        }
+    }
+
+    @Nested
+    @DisplayName("OperationTextRenderContext Equality and ToString")
+    class OperationTextRenderContextEqualityAndToString {
+
+        @Test
+        @DisplayName("Should be equal when all fields match")
+        void shouldBeEqualWhenAllFieldsMatch() {
+            Instant expiration = Instant.now();
+            OperationRequestContext requestContext = OperationRequestContext.builder()
+                    .channel("web")
+                    .build();
+
+            OperationTextRenderContext context1 = OperationTextRenderContext.builder()
+                    .operationProposal("policy")
+                    .originalPrompt("prompt")
+                    .requestContext(requestContext)
+                    .tokenExpiration(expiration)
+                    .build();
+
+            OperationTextRenderContext context2 = OperationTextRenderContext.builder()
+                    .operationProposal("policy")
+                    .originalPrompt("prompt")
+                    .requestContext(requestContext)
+                    .tokenExpiration(expiration)
+                    .build();
+
+            assertThat(context1).isEqualTo(context2);
+            assertThat(context1.hashCode()).isEqualTo(context2.hashCode());
+        }
+
+        @Test
+        @DisplayName("Should not be equal when operationProposal differs")
+        void shouldNotBeEqualWhenOperationProposalDiffers() {
+            OperationTextRenderContext context1 = OperationTextRenderContext.builder()
+                    .operationProposal("policy1")
+                    .build();
+            OperationTextRenderContext context2 = OperationTextRenderContext.builder()
+                    .operationProposal("policy2")
+                    .build();
+
+            assertThat(context1).isNotEqualTo(context2);
+        }
+
+        @Test
+        @DisplayName("Should not be equal when originalPrompt differs")
+        void shouldNotBeEqualWhenOriginalPromptDiffers() {
+            OperationTextRenderContext context1 = OperationTextRenderContext.builder()
+                    .originalPrompt("prompt1")
+                    .build();
+            OperationTextRenderContext context2 = OperationTextRenderContext.builder()
+                    .originalPrompt("prompt2")
+                    .build();
+
+            assertThat(context1).isNotEqualTo(context2);
+        }
+
+        @Test
+        @DisplayName("Should not be equal when tokenExpiration differs")
+        void shouldNotBeEqualWhenTokenExpirationDiffers() {
+            OperationTextRenderContext context1 = OperationTextRenderContext.builder()
+                    .tokenExpiration(Instant.ofEpochSecond(1000))
+                    .build();
+            OperationTextRenderContext context2 = OperationTextRenderContext.builder()
+                    .tokenExpiration(Instant.ofEpochSecond(2000))
+                    .build();
+
+            assertThat(context1).isNotEqualTo(context2);
+        }
+
+        @Test
+        @DisplayName("Should be reflexive")
+        void shouldBeReflexive() {
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .originalPrompt("test")
+                    .build();
+
+            assertThat(context).isEqualTo(context);
+        }
+
+        @Test
+        @DisplayName("Should not be equal to null")
+        void shouldNotBeEqualToNull() {
+            OperationTextRenderContext context = OperationTextRenderContext.builder().build();
+
+            assertThat(context).isNotEqualTo(null);
+        }
+
+        @Test
+        @DisplayName("Should not be equal to different type")
+        void shouldNotBeEqualToDifferentType() {
+            OperationTextRenderContext context = OperationTextRenderContext.builder().build();
+
+            assertThat(context).isNotEqualTo("not a context");
+        }
+
+        @Test
+        @DisplayName("Should have consistent hashCode")
+        void shouldHaveConsistentHashCode() {
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .originalPrompt("test")
+                    .operationProposal("policy")
+                    .build();
+
+            assertThat(context.hashCode()).isEqualTo(context.hashCode());
+        }
+
+        @Test
+        @DisplayName("toString should contain key fields")
+        void toStringShouldContainKeyFields() {
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .originalPrompt("Buy books")
+                    .operationProposal("allow read access to bookstore")
+                    .build();
+
+            String stringRepresentation = context.toString();
+
+            assertThat(stringRepresentation).contains("Buy books");
+            assertThat(stringRepresentation).contains("operationProposal");
+        }
+
+        @Test
+        @DisplayName("toString should truncate long operationProposal")
+        void toStringShouldTruncateLongOperationProposal() {
+            String longProposal = "This is a very long operation proposal that definitely exceeds the fifty character limit for display";
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .operationProposal(longProposal)
+                    .build();
+
+            String stringRepresentation = context.toString();
+
+            assertThat(stringRepresentation).contains("...");
+            assertThat(stringRepresentation).doesNotContain(longProposal);
+        }
+
+        @Test
+        @DisplayName("toString should handle null operationProposal")
+        void toStringShouldHandleNullOperationProposal() {
+            OperationTextRenderContext context = OperationTextRenderContext.builder().build();
+
+            String stringRepresentation = context.toString();
+
+            assertThat(stringRepresentation).contains("null");
+        }
+
+        @Test
+        @DisplayName("Two empty contexts should be equal")
+        void twoEmptyContextsShouldBeEqual() {
+            OperationTextRenderContext context1 = OperationTextRenderContext.builder().build();
+            OperationTextRenderContext context2 = OperationTextRenderContext.builder().build();
+
+            assertThat(context1).isEqualTo(context2);
+            assertThat(context1.hashCode()).isEqualTo(context2.hashCode());
+        }
+    }
+}

--- a/open-agent-auth-core/src/test/java/com/alibaba/openagentauth/core/protocol/oauth2/token/aoat/DefaultAoatTokenGeneratorTest.java
+++ b/open-agent-auth-core/src/test/java/com/alibaba/openagentauth/core/protocol/oauth2/token/aoat/DefaultAoatTokenGeneratorTest.java
@@ -15,6 +15,12 @@
  */
 package com.alibaba.openagentauth.core.protocol.oauth2.token.aoat;
 
+import com.alibaba.openagentauth.core.audit.model.OperationTextRenderResult;
+import com.alibaba.openagentauth.core.audit.api.OperationTextRenderer;
+import com.alibaba.openagentauth.core.audit.model.SemanticExpansionLevel;
+import com.alibaba.openagentauth.core.binding.BindingInstanceStore;
+import com.alibaba.openagentauth.core.binding.InMemoryBindingInstanceStore;
+import com.alibaba.openagentauth.core.crypto.jwe.JweDecoder;
 import com.alibaba.openagentauth.core.exception.oauth2.OAuth2TokenException;
 import com.alibaba.openagentauth.core.model.context.OperationRequestContext;
 import com.alibaba.openagentauth.core.model.evidence.Evidence;
@@ -26,6 +32,7 @@ import com.alibaba.openagentauth.core.model.policy.PolicyMetadata;
 import com.alibaba.openagentauth.core.model.policy.PolicyRegistration;
 import com.alibaba.openagentauth.core.model.token.AgentOperationAuthToken;
 import com.alibaba.openagentauth.core.policy.api.PolicyRegistry;
+import com.alibaba.openagentauth.core.protocol.vc.jwe.PromptDecryptionService;
 import com.alibaba.openagentauth.core.token.aoat.AoatGenerator;
 import com.alibaba.openagentauth.core.protocol.vc.VcVerifier;
 import com.nimbusds.jose.JOSEException;
@@ -74,8 +81,13 @@ class DefaultAoatTokenGeneratorTest {
     @Mock
     private PolicyRegistry policyRegistry;
 
+    @Mock
+    private JweDecoder jweDecoder;
+
     private DefaultAoatTokenGenerator generator;
     private AoatGenerator aoatGenerator;
+    private BindingInstanceStore bindingInstanceStore;
+    private PromptDecryptionService promptDecryptionService;
     private static final String SUBJECT = "user_12345";
     private static final String ISSUER = "https://as.example.com";
     private static final String AUDIENCE = "https://api.example.com";
@@ -86,6 +98,12 @@ class DefaultAoatTokenGeneratorTest {
         // Create a real AoatGenerator instance instead of mocking
         RSAKey signingKey = new RSAKeyGenerator(2048).keyID("test-signing-key").generate();
         aoatGenerator = new AoatGenerator(signingKey, JWSAlgorithm.RS256, ISSUER, AUDIENCE);
+
+        // Create binding instance store
+        bindingInstanceStore = new InMemoryBindingInstanceStore();
+
+        // Create prompt decryption service (disabled for tests)
+        promptDecryptionService = new PromptDecryptionService(jweDecoder, false);
 
         // Setup policyRegistry mock to return valid policy registration
         String testPolicyId = "policy-" + UUID.randomUUID().toString();
@@ -366,6 +384,301 @@ class DefaultAoatTokenGeneratorTest {
             // Assert
             assertThat(result).isNotNull();
             assertThat(result.getReferences()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("OperationTextRenderer Strategy Pattern")
+    class OperationTextRendererStrategy {
+
+        @Test
+        @DisplayName("Should accept custom OperationTextRenderer via constructor")
+        void shouldAcceptCustomOperationTextRenderer() {
+            // Arrange
+            OperationTextRenderer customRenderer = context -> 
+                OperationTextRenderResult.withMediumExpansion("Custom rendered text");
+
+            // Act
+            DefaultAoatTokenGenerator generatorWithCustomRenderer = new DefaultAoatTokenGenerator(
+                    aoatGenerator,
+                    vcVerifier,
+                    policyRegistry,
+                    bindingInstanceStore,
+                    promptDecryptionService,
+                    customRenderer,
+                    EXPIRATION_SECONDS
+            );
+
+            // Assert - generator should be created successfully
+            assertThat(generatorWithCustomRenderer).isNotNull();
+            assertThat(generatorWithCustomRenderer.getDefaultTokenExpirationSeconds())
+                    .isEqualTo(EXPIRATION_SECONDS);
+        }
+
+        @Test
+        @DisplayName("Should use PatternBasedOperationTextRenderer as default")
+        void shouldUsePatternBasedOperationTextRendererAsDefault() throws Exception {
+            // Arrange
+            String vcJwt = "valid_vc_jwt";
+            Evidence evidence = Evidence.builder()
+                    .sourcePromptCredential(vcJwt)
+                    .build();
+
+            OperationRequestContext requestContext = OperationRequestContext.builder()
+                    .channel("mobile-app")
+                    .agent(OperationRequestContext.AgentContext.builder()
+                            .platform("personal-agent.example.com")
+                            .client("mobile-app-v1")
+                            .instance("dfp_abc123")
+                            .build())
+                    .build();
+
+            ParJwtClaims parClaims = ParJwtClaims.builder()
+                    .operationProposal("allow { input.amount <= 50.0 }")
+                    .evidence(evidence)
+                    .context(requestContext)
+                    .build();
+
+            UserInputEvidence credentialSubject = UserInputEvidence.builder()
+                    .prompt("Buy something cheap")
+                    .timestamp(Instant.now())
+                    .build();
+
+            VerifiableCredential vc = VerifiableCredential.builder()
+                    .jti("vc-123")
+                    .credentialSubject(credentialSubject)
+                    .build();
+
+            when(vcVerifier.verify(vcJwt)).thenReturn(vc);
+
+            // Act
+            AgentOperationAuthToken result = generator.generateAoat(SUBJECT, parClaims);
+
+            // Assert - verify that rendered text contains expected elements
+            assertThat(result).isNotNull();
+            assertThat(result.getContext()).isNotNull();
+            assertThat(result.getContext().getRenderedText()).isNotNull();
+            
+            // PatternBasedOperationTextRenderer should include the original prompt
+            assertThat(result.getContext().getRenderedText())
+                    .contains("Buy something cheap");
+            
+            // Verify audit trail contains rendered operation text
+            assertThat(result.getAuditTrail()).isNotNull();
+            assertThat(result.getAuditTrail().getRenderedOperationText()).isNotNull();
+            assertThat(result.getAuditTrail().getSemanticExpansionLevel()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("Should use custom renderer for rendered text")
+        void shouldUseCustomRendererForRenderedText() throws Exception {
+            // Arrange
+            String customRenderedText = "CUSTOM: Authorized operation with custom renderer";
+            OperationTextRenderer customRenderer = context -> 
+                OperationTextRenderResult.withMediumExpansion(customRenderedText);
+
+            // Note: We cannot test the constructor with custom OperationTextRenderer here because
+            // it requires BindingInstanceStore which needs a valid WIT (Workload Identity Token).
+            // This test verifies that the custom renderer logic works correctly.
+            // The constructor signature test is covered in shouldAcceptCustomOperationTextRenderer().
+            
+            String vcJwt = "valid_vc_jwt";
+            Evidence evidence = Evidence.builder()
+                    .sourcePromptCredential(vcJwt)
+                    .build();
+
+            OperationRequestContext requestContext = OperationRequestContext.builder()
+                    .channel("mobile-app")
+                    .agent(OperationRequestContext.AgentContext.builder()
+                            .platform("personal-agent.example.com")
+                            .client("mobile-app-v1")
+                            .instance("dfp_abc123")
+                            .build())
+                    .build();
+
+            ParJwtClaims parClaims = ParJwtClaims.builder()
+                    .operationProposal("allow { true }")
+                    .evidence(evidence)
+                    .context(requestContext)
+                    .build();
+
+            UserInputEvidence credentialSubject = UserInputEvidence.builder()
+                    .prompt("Test prompt")
+                    .timestamp(Instant.now())
+                    .build();
+
+            VerifiableCredential vc = VerifiableCredential.builder()
+                    .jti("vc-123")
+                    .credentialSubject(credentialSubject)
+                    .build();
+
+            when(vcVerifier.verify(vcJwt)).thenReturn(vc);
+
+            // Act
+            AgentOperationAuthToken result = generator.generateAoat(SUBJECT, parClaims);
+
+            // Assert - verify that default renderer is used (PatternBasedOperationTextRenderer)
+            assertThat(result).isNotNull();
+            assertThat(result.getContext()).isNotNull();
+            assertThat(result.getContext().getRenderedText()).isNotNull();
+            
+            // Verify audit trail contains rendered operation text
+            assertThat(result.getAuditTrail()).isNotNull();
+            assertThat(result.getAuditTrail().getRenderedOperationText()).isNotNull();
+            assertThat(result.getAuditTrail().getSemanticExpansionLevel()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("Should render operation text without evidence")
+        void shouldRenderOperationTextWithoutEvidence() throws Exception {
+            // Arrange
+            OperationRequestContext requestContext = OperationRequestContext.builder()
+                    .channel("mobile-app")
+                    .agent(OperationRequestContext.AgentContext.builder()
+                            .platform("personal-agent.example.com")
+                            .client("mobile-app-v1")
+                            .instance("dfp_abc123")
+                            .build())
+                    .build();
+
+            ParJwtClaims parClaims = ParJwtClaims.builder()
+                    .operationProposal("allow { input.amount <= 100.0 }")
+                    .evidence(null)
+                    .context(requestContext)
+                    .build();
+
+            // Act
+            AgentOperationAuthToken result = generator.generateAoat(SUBJECT, parClaims);
+
+            // Assert
+            assertThat(result).isNotNull();
+            assertThat(result.getContext()).isNotNull();
+            assertThat(result.getContext().getRenderedText()).isNotNull();
+            
+            // PatternBasedOperationTextRenderer should use policy preview when no prompt available
+            assertThat(result.getContext().getRenderedText())
+                    .contains("Authorized agent operation per policy:");
+            
+            // Verify audit trail
+            assertThat(result.getAuditTrail()).isNotNull();
+            assertThat(result.getAuditTrail().getRenderedOperationText())
+                    .isEqualTo(result.getContext().getRenderedText());
+        }
+
+        @Test
+        @DisplayName("Should include context information in rendered text")
+        void shouldIncludeContextInformationInRenderedText() throws Exception {
+            // Arrange
+            OperationRequestContext context = OperationRequestContext.builder()
+                    .channel("mobile-app")
+                    .agent(OperationRequestContext.AgentContext.builder()
+                            .platform("personal-agent.example.com")
+                            .client("mobile-app-v1")
+                            .instance("dfp_abc123")
+                            .build())
+                    .build();
+
+            ParJwtClaims parClaims = ParJwtClaims.builder()
+                    .operationProposal("allow { true }")
+                    .context(context)
+                    .build();
+
+            // Act
+            AgentOperationAuthToken result = generator.generateAoat(SUBJECT, parClaims);
+
+            // Assert
+            assertThat(result).isNotNull();
+            assertThat(result.getContext()).isNotNull();
+            assertThat(result.getContext().getRenderedText()).isNotNull();
+            
+            // PatternBasedOperationTextRenderer should include channel and platform
+            assertThat(result.getContext().getRenderedText())
+                    .contains("mobile-app");
+            assertThat(result.getContext().getRenderedText())
+                    .contains("personal-agent.example.com");
+        }
+
+        @Test
+        @DisplayName("Should include expiration time in rendered text")
+        void shouldIncludeExpirationTimeInRenderedText() throws Exception {
+            // Arrange
+            OperationRequestContext requestContext = OperationRequestContext.builder()
+                    .channel("mobile-app")
+                    .agent(OperationRequestContext.AgentContext.builder()
+                            .platform("personal-agent.example.com")
+                            .client("mobile-app-v1")
+                            .instance("dfp_abc123")
+                            .build())
+                    .build();
+
+            ParJwtClaims parClaims = ParJwtClaims.builder()
+                    .operationProposal("allow { true }")
+                    .context(requestContext)
+                    .build();
+
+            // Act
+            AgentOperationAuthToken result = generator.generateAoat(SUBJECT, parClaims);
+
+            // Assert
+            assertThat(result).isNotNull();
+            assertThat(result.getContext()).isNotNull();
+            assertThat(result.getContext().getRenderedText()).isNotNull();
+            
+            // PatternBasedOperationTextRenderer should include expiration time
+            assertThat(result.getContext().getRenderedText())
+                    .contains("valid until");
+        }
+
+        @Test
+        @DisplayName("Should set correct semantic expansion level")
+        void shouldSetCorrectSemanticExpansionLevel() throws Exception {
+            // Arrange
+            String vcJwt = "valid_vc_jwt";
+            Evidence evidence = Evidence.builder()
+                    .sourcePromptCredential(vcJwt)
+                    .build();
+
+            ParJwtClaims parClaims = ParJwtClaims.builder()
+                    .operationProposal("allow { true }")
+                    .evidence(evidence)
+                    .build();
+
+            UserInputEvidence credentialSubject = UserInputEvidence.builder()
+                    .prompt("Test prompt with content")
+                    .timestamp(Instant.now())
+                    .build();
+
+            VerifiableCredential vc = VerifiableCredential.builder()
+                    .jti("vc-123")
+                    .credentialSubject(credentialSubject)
+                    .build();
+
+            when(vcVerifier.verify(vcJwt)).thenReturn(vc);
+
+            // Act
+            AgentOperationAuthToken result = generator.generateAoat(SUBJECT, parClaims);
+
+            // Assert
+            assertThat(result).isNotNull();
+            assertThat(result.getAuditTrail()).isNotNull();
+            
+            // PatternBasedOperationTextRenderer returns LOW expansion when prompt is present
+            assertThat(result.getAuditTrail().getSemanticExpansionLevel())
+                    .isEqualTo(SemanticExpansionLevel.LOW.getValue());
+        }
+
+        @Test
+        @DisplayName("Should handle null operation proposal gracefully")
+        void shouldHandleNullOperationProposalGracefully() throws Exception {
+            // Arrange
+            ParJwtClaims parClaims = ParJwtClaims.builder()
+                    .operationProposal(null)
+                    .build();
+
+            // Act & Assert
+            assertThatThrownBy(() -> generator.generateAoat(SUBJECT, parClaims))
+                    .isInstanceOf(OAuth2TokenException.class)
+                    .hasMessageContaining("Missing operation proposal");
         }
     }
 }

--- a/open-agent-auth-spring-boot-starter/src/main/java/com/alibaba/openagentauth/spring/autoconfigure/role/AuthorizationServerAutoConfiguration.java
+++ b/open-agent-auth-spring-boot-starter/src/main/java/com/alibaba/openagentauth/spring/autoconfigure/role/AuthorizationServerAutoConfiguration.java
@@ -54,6 +54,8 @@ import com.alibaba.openagentauth.core.protocol.oauth2.token.server.TokenGenerato
 import com.alibaba.openagentauth.core.protocol.vc.DefaultVcVerifier;
 import com.alibaba.openagentauth.core.protocol.vc.VcVerificationPolicy;
 import com.alibaba.openagentauth.core.protocol.vc.VcVerifier;
+import com.alibaba.openagentauth.core.audit.api.OperationTextRenderer;
+import com.alibaba.openagentauth.core.audit.impl.PatternBasedOperationTextRenderer;
 import com.alibaba.openagentauth.core.protocol.vc.jwe.PromptDecryptionService;
 import com.alibaba.openagentauth.core.resolver.ServiceEndpointResolver;
 import com.alibaba.openagentauth.core.token.aoat.AoatGenerator;
@@ -507,12 +509,28 @@ public class AuthorizationServerAutoConfiguration {
         private static final Logger logger = LoggerFactory.getLogger(AuthorizationCoreConfiguration.class);
 
         @Bean
+        @ConditionalOnMissingBean(OperationTextRenderer.class)
+        public OperationTextRenderer operationTextRenderer() {
+            logger.info("Creating default PatternBasedOperationTextRenderer bean");
+            return new PatternBasedOperationTextRenderer();
+        }
+
+        @Bean
         @ConditionalOnMissingBean
-        public AoatTokenGenerator aoatTokenGenerator(AoatGenerator aoatGenerator, VcVerifier vcVerifier, PolicyRegistry policyRegistry, BindingInstanceStore bindingInstanceStore, PromptDecryptionService promptDecryptionService, OpenAgentAuthProperties openAgentAuthProperties) {
+        public AoatTokenGenerator aoatTokenGenerator(
+                AoatGenerator aoatGenerator,
+                VcVerifier vcVerifier,
+                PolicyRegistry policyRegistry,
+                BindingInstanceStore bindingInstanceStore,
+                PromptDecryptionService promptDecryptionService,
+                OperationTextRenderer operationTextRenderer,
+                OpenAgentAuthProperties openAgentAuthProperties) {
             logger.info("Creating AoatTokenGenerator bean");
             var tokenProps = openAgentAuthProperties.getCapabilities().getOAuth2Server().getToken();
             long tokenExpiration = tokenProps.getAccessTokenExpiry();
-            return new DefaultAoatTokenGenerator(aoatGenerator, vcVerifier, policyRegistry, bindingInstanceStore, promptDecryptionService, tokenExpiration);
+            return new DefaultAoatTokenGenerator(
+                    aoatGenerator, vcVerifier, policyRegistry, bindingInstanceStore,
+                    promptDecryptionService, operationTextRenderer, tokenExpiration);
         }
 
         @Bean
@@ -593,9 +611,9 @@ public class AuthorizationServerAutoConfiguration {
 
         @Bean
         @ConditionalOnMissingBean
-        public ConsentPageProvider consentPageProvider() {
+        public ConsentPageProvider consentPageProvider(PromptDecryptionService promptDecryptionService) {
             logger.info("Creating ConsentPageProvider bean with DefaultConsentPageProvider for Authorization Server");
-            return new DefaultConsentPageProvider(CONSENT_TEMPLATE_AOA);
+            return new DefaultConsentPageProvider(CONSENT_TEMPLATE_AOA, "Authorization Server", promptDecryptionService);
         }
     }
 }

--- a/open-agent-auth-spring-boot-starter/src/main/java/com/alibaba/openagentauth/spring/web/provider/DefaultConsentPageProvider.java
+++ b/open-agent-auth-spring-boot-starter/src/main/java/com/alibaba/openagentauth/spring/web/provider/DefaultConsentPageProvider.java
@@ -17,13 +17,22 @@ package com.alibaba.openagentauth.spring.web.provider;
 
 import com.alibaba.openagentauth.core.model.context.OperationRequestContext;
 import com.alibaba.openagentauth.core.model.evidence.Evidence;
+import com.alibaba.openagentauth.core.model.evidence.VerifiableCredential;
 import com.alibaba.openagentauth.core.model.oauth2.par.ParJwtClaims;
 import com.alibaba.openagentauth.core.model.proposal.AgentUserBindingProposal;
+import com.alibaba.openagentauth.core.protocol.vc.jwe.PromptDecryptionService;
+import com.alibaba.openagentauth.core.protocol.vc.jwt.JwtVcDecoder;
 import com.alibaba.openagentauth.framework.web.provider.ConsentPageProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.servlet.ModelAndView;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
 /**
  * Default implementation of {@link ConsentPageProvider}.
@@ -78,10 +87,19 @@ public class DefaultConsentPageProvider implements ConsentPageProvider {
     private final String displayName;
 
     /**
+     * Service for decrypting JWE-encrypted user prompts.
+     * <p>
+     * When the source prompt credential is JWE-encrypted, this service decrypts it
+     * so the consent page can display the human-readable original user input.
+     * </p>
+     */
+    private final PromptDecryptionService promptDecryptionService;
+
+    /**
      * Creates a new DefaultConsentPageProvider with default view name.
      */
     public DefaultConsentPageProvider() {
-        this(DEFAULT_VIEW_NAME, "Identity Provider");
+        this(DEFAULT_VIEW_NAME, "Identity Provider", null);
     }
 
     /**
@@ -90,7 +108,7 @@ public class DefaultConsentPageProvider implements ConsentPageProvider {
      * @param viewName the Thymeleaf template view name
      */
     public DefaultConsentPageProvider(String viewName) {
-        this(viewName, "Identity Provider");
+        this(viewName, "Identity Provider", null);
     }
 
     /**
@@ -100,8 +118,22 @@ public class DefaultConsentPageProvider implements ConsentPageProvider {
      * @param displayName the display name for the IDP
      */
     public DefaultConsentPageProvider(String viewName, String displayName) {
+        this(viewName, displayName, null);
+    }
+
+    /**
+     * Creates a new DefaultConsentPageProvider with custom view name, display name,
+     * and prompt decryption service.
+     *
+     * @param viewName the Thymeleaf template view name
+     * @param displayName the display name for the IDP
+     * @param promptDecryptionService the service for decrypting JWE-encrypted prompts (nullable)
+     */
+    public DefaultConsentPageProvider(String viewName, String displayName,
+                                      PromptDecryptionService promptDecryptionService) {
         this.viewName = viewName;
         this.displayName = displayName;
+        this.promptDecryptionService = promptDecryptionService;
     }
 
     @Override
@@ -151,6 +183,9 @@ public class DefaultConsentPageProvider implements ConsentPageProvider {
             if (evidence != null) {
                 mv.addObject("evidence", evidence);
                 mv.addObject("sourcePromptCredential", evidence.getSourcePromptCredential());
+                
+                // Decode JWT-VC to extract human-readable original user input
+                decodeAndAddUserInput(mv, evidence.getSourcePromptCredential());
             }
 
             String operationProposal = parClaims.getOperationProposal();
@@ -182,6 +217,148 @@ public class DefaultConsentPageProvider implements ConsentPageProvider {
 
         logger.info("User consent action: {}, approved: {}", action, approved);
         return approved;
+    }
+
+    /**
+     * Decodes the JWT-VC source prompt credential and adds human-readable user input to the model.
+     * <p>
+     * According to draft-liu-agent-operation-authorization-01 Section 3, the evidence field
+     * contains a JWT-VC with the user's original natural-language instruction. The prompt
+     * inside the JWT-VC's {@code credentialSubject} may itself be JWE-encrypted for privacy
+     * protection. This method handles two layers of protection:
+     * </p>
+     * <ol>
+     *   <li><b>Outer layer:</b> The entire {@code sourcePromptCredential} may be JWE-wrapped.
+     *       If so, it is decrypted first to obtain the signed JWT-VC.</li>
+     *   <li><b>Inner layer:</b> The {@code prompt} field inside the JWT-VC's credential subject
+     *       may be JWE-encrypted. After JWT-VC decoding, the prompt is decrypted to obtain
+     *       the human-readable text.</li>
+     * </ol>
+     *
+     * @param modelAndView the ModelAndView to add decoded information to
+     * @param sourcePromptCredential the JWT-VC string (possibly JWE-encrypted)
+     */
+    private void decodeAndAddUserInput(ModelAndView modelAndView, String sourcePromptCredential) {
+        if (sourcePromptCredential == null || sourcePromptCredential.isEmpty()) {
+            return;
+        }
+
+        try {
+            // The sourcePromptCredential may be either a JWE-encrypted JWT-VC or a plain JWT-VC.
+            // Attempt outer-level decryption first (handles JWE-wrapped JWT-VC).
+            String jwtVcString = tryDecryptOrPassthrough(sourcePromptCredential);
+
+            // If the string is still in JWE format (5 dot-separated segments) after
+            // decryption attempt, it cannot be parsed as a signed JWT — skip decoding.
+            if (isJweFormat(jwtVcString)) {
+                logger.warn("Source prompt credential is JWE-encrypted and could not be decrypted. "
+                        + "The raw credential will be shown on the consent page.");
+                return;
+            }
+
+            VerifiableCredential verifiableCredential = JwtVcDecoder.decode(jwtVcString);
+            populateModelFromCredential(modelAndView, verifiableCredential);
+            logger.debug("Successfully decoded JWT-VC for consent page display");
+        } catch (Exception e) {
+            logger.warn("Failed to decode source prompt credential for consent page display. "
+                    + "The raw JWT-VC will still be shown. Error: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Checks whether the given string is in JWE compact serialization format.
+     * <p>
+     * JWE compact serialization consists of 5 Base64url-encoded parts separated by dots:
+     * {@code header.encryptedKey.iv.ciphertext.tag}
+     * </p>
+     *
+     * @param token the token string to check
+     * @return true if the string has exactly 5 dot-separated segments (JWE format)
+     */
+    private boolean isJweFormat(String token) {
+        if (token == null || token.isEmpty()) {
+            return false;
+        }
+        long dotCount = token.chars().filter(ch -> ch == '.').count();
+        return dotCount == 4;
+    }
+
+    /**
+     * Attempts to decrypt the credential string. If decryption fails (e.g., missing JWK),
+     * returns the original string unchanged so that direct JWT parsing can be attempted.
+     *
+     * @param sourcePromptCredential the credential string (JWE or plain JWT)
+     * @return the decrypted JWT string, or the original string if decryption is unavailable or fails
+     */
+    private String tryDecryptOrPassthrough(String sourcePromptCredential) {
+        if (promptDecryptionService == null) {
+            return sourcePromptCredential;
+        }
+        try {
+            return promptDecryptionService.decryptPrompt(sourcePromptCredential);
+        } catch (Exception decryptionError) {
+            logger.debug("JWE decryption failed ({}), attempting direct JWT parsing",
+                    decryptionError.getMessage());
+            return sourcePromptCredential;
+        }
+    }
+
+    /**
+     * Populates the ModelAndView with human-readable fields extracted from the decoded credential.
+     *
+     * @param modelAndView the ModelAndView to populate
+     * @param credential the decoded VerifiableCredential
+     */
+    private void populateModelFromCredential(ModelAndView modelAndView, VerifiableCredential credential) {
+        modelAndView.addObject("decodedCredential", credential);
+
+        if (credential.getCredentialSubject() == null) {
+            return;
+        }
+
+        String originalPrompt = credential.getCredentialSubject().getPrompt();
+        if (originalPrompt != null && !originalPrompt.isEmpty()) {
+            // The prompt field inside the JWT-VC may itself be JWE-encrypted.
+            // Attempt decryption so the consent page shows the human-readable text.
+            String decryptedPrompt = tryDecryptOrPassthrough(originalPrompt);
+            if (isJweFormat(decryptedPrompt)) {
+                logger.warn("Prompt inside JWT-VC credential is JWE-encrypted and could not be decrypted.");
+            } else {
+                modelAndView.addObject("originalUserPrompt", decryptedPrompt);
+            }
+        }
+
+        String inputChannel = credential.getCredentialSubject().getChannel();
+        if (inputChannel != null && !inputChannel.isEmpty()) {
+            modelAndView.addObject("inputChannel", inputChannel);
+        }
+
+        String inputTimestamp = credential.getCredentialSubject().getTimestamp();
+        if (inputTimestamp != null && !inputTimestamp.isEmpty()) {
+            modelAndView.addObject("inputTimestamp", formatTimestamp(inputTimestamp));
+        }
+    }
+
+    /**
+     * Formats an ISO 8601 UTC timestamp into a human-readable local date-time string.
+     * <p>
+     * Converts timestamps like {@code 2025-11-11T10:30:00Z} into {@code 2025-11-11 10:30:00 UTC}.
+     * If parsing fails, returns the original string unchanged.
+     * </p>
+     *
+     * @param isoTimestamp the ISO 8601 timestamp string
+     * @return the formatted timestamp, or the original string if parsing fails
+     */
+    private String formatTimestamp(String isoTimestamp) {
+        try {
+            Instant instant = Instant.parse(isoTimestamp);
+            ZonedDateTime zonedDateTime = instant.atZone(ZoneOffset.UTC);
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MMM d, yyyy, h:mm a 'UTC'", Locale.ENGLISH);
+            return zonedDateTime.format(formatter);
+        } catch (Exception e) {
+            logger.debug("Failed to parse timestamp '{}', using original value", isoTimestamp);
+            return isoTimestamp;
+        }
     }
 
     @Override

--- a/open-agent-auth-spring-boot-starter/src/main/resources/templates/oauth2/aoa_consent.html
+++ b/open-agent-auth-spring-boot-starter/src/main/resources/templates/oauth2/aoa_consent.html
@@ -354,6 +354,107 @@
             color: var(--color-text-secondary);
         }
 
+        .user-prompt-quote {
+            position: relative;
+            padding: var(--space-4) var(--space-5);
+            background: linear-gradient(135deg, var(--color-primary-bg-soft), transparent 60%);
+            border-left: 3px solid var(--color-primary);
+            border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+            margin-bottom: var(--space-2);
+        }
+
+        .user-prompt-quote::before {
+            content: '\201C';
+            position: absolute;
+            top: -4px;
+            left: 10px;
+            font-size: 2.5rem;
+            color: var(--color-primary-light);
+            font-family: Georgia, 'Times New Roman', serif;
+            line-height: 1;
+            opacity: 0.6;
+        }
+
+        .user-prompt-text {
+            color: var(--color-text-primary);
+            font-size: var(--font-size-base);
+            font-weight: var(--font-weight-medium);
+            line-height: 1.7;
+            font-style: italic;
+            padding-left: var(--space-4);
+        }
+
+        .user-prompt-meta {
+            display: flex;
+            gap: var(--space-4);
+            margin-top: var(--space-2);
+            padding-left: var(--space-4);
+            font-size: var(--font-size-xs);
+            color: var(--color-text-tertiary);
+        }
+
+        .user-prompt-meta span {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+        }
+
+        .context-flow {
+            display: flex;
+            flex-wrap: wrap;
+            gap: var(--space-2);
+        }
+
+        .context-chip {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            background: var(--color-surface-warm);
+            border: 1px solid var(--color-border);
+            padding: 5px 12px;
+            border-radius: var(--radius-full);
+            font-size: var(--font-size-xs);
+            color: var(--color-text-secondary);
+            font-weight: var(--font-weight-medium);
+            transition: all var(--transition-fast);
+        }
+
+        .context-chip i {
+            color: var(--color-primary-light);
+            font-size: 11px;
+        }
+
+        .context-chip .chip-label {
+            color: var(--color-text-tertiary);
+            font-weight: normal;
+        }
+
+        .meta-row {
+            display: flex;
+            align-items: baseline;
+            padding: 6px 0;
+            font-size: var(--font-size-sm);
+            border-bottom: 1px solid var(--color-border);
+        }
+
+        .meta-row:last-child {
+            border-bottom: none;
+        }
+
+        .meta-row .meta-key {
+            color: var(--color-text-tertiary);
+            font-size: var(--font-size-xs);
+            font-weight: var(--font-weight-medium);
+            min-width: 100px;
+            flex-shrink: 0;
+        }
+
+        .meta-row .meta-val {
+            color: var(--color-text-primary);
+            font-weight: var(--font-weight-medium);
+            word-break: break-word;
+        }
+
         .collapsible {
             margin-top: var(--space-3);
         }
@@ -607,11 +708,27 @@
                     
                     <div class="auth-section" th:if="${parClaims.evidence != null and parClaims.evidence.sourcePromptCredential != null}">
                         <div class="auth-section-title">
-                            <i class="bi bi-file-text"></i> User Original Input (JWT-VC)
+                            <i class="bi bi-chat-quote"></i> User Original Input
                         </div>
+                        
+                        <!-- Human-readable original prompt with quotation styling -->
+                        <div th:if="${originalUserPrompt != null}">
+                            <div class="user-prompt-quote">
+                                <div class="user-prompt-text" th:text="${originalUserPrompt}">Buy something cheap on Nov 11 night</div>
+                                <div class="user-prompt-meta">
+                                    <span th:if="${inputChannel != null}"><i class="bi bi-broadcast"></i> <span th:text="${inputChannel}">voice</span></span>
+                                    <span th:if="${inputTimestamp != null}"><i class="bi bi-clock"></i> <span th:text="${inputTimestamp}">Nov 11, 2025, 10:30 AM UTC</span></span>
+                                </div>
+                            </div>
+                        </div>
+                        
+                        <!-- Fallback: show raw JWT-VC if decoding failed -->
+                        <div th:if="${originalUserPrompt == null}" class="jwt-block" th:text="${parClaims.evidence.sourcePromptCredential}">jwt-vc</div>
+                        
+                        <!-- Collapsible raw JWT-VC for technical verification -->
                         <div class="collapsible">
                             <div class="collapsible-header" onclick="toggleCollapse(this)">
-                                <span><i class="bi bi-key"></i> Source Prompt Credential</span>
+                                <span><i class="bi bi-key"></i> Source Prompt Credential (JWT-VC)</span>
                                 <span class="arrow"><i class="bi bi-chevron-down"></i></span>
                             </div>
                             <div class="collapsible-content">
@@ -620,66 +737,59 @@
                         </div>
                     </div>
                     
+                    <!-- Unified Execution Context: merges request context, user, and agent info into a compact chip-flow -->
                     <div class="auth-section" th:if="${parClaims.context != null}">
                         <div class="auth-section-title">
-                            <i class="bi bi-globe"></i> Request Context
+                            <i class="bi bi-diagram-3"></i> Execution Context
                         </div>
-                        <div class="info-grid">
-                            <div class="info-item" th:if="${parClaims.context.channel != null}">
-                                <div class="info-label">Channel</div>
-                                <div class="info-value" th:text="${parClaims.context.channel}">web</div>
+                        <div class="context-flow">
+                            <div class="context-chip" th:if="${parClaims.context.channel != null}">
+                                <i class="bi bi-broadcast"></i>
+                                <span class="chip-label">Channel</span>
+                                <span th:text="${parClaims.context.channel}">web</span>
                             </div>
-                            <div class="info-item" th:if="${parClaims.context.language != null}">
-                                <div class="info-label">Language</div>
-                                <div class="info-value" th:text="${parClaims.context.language}">en-US</div>
+                            <div class="context-chip" th:if="${parClaims.context.language != null}">
+                                <i class="bi bi-translate"></i>
+                                <span class="chip-label">Lang</span>
+                                <span th:text="${parClaims.context.language}">en-US</span>
                             </div>
-                            <div class="info-item" th:if="${parClaims.context.deviceFingerprint != null}">
-                                <div class="info-label">Device Fingerprint</div>
-                                <div class="info-value" th:text="${parClaims.context.deviceFingerprint}">device-id</div>
+                            <div class="context-chip" th:if="${parClaims.context.user != null and parClaims.context.user.id != null}">
+                                <i class="bi bi-person"></i>
+                                <span class="chip-label">User</span>
+                                <span th:text="${parClaims.context.user.id}">user-id</span>
                             </div>
-                        </div>
-                    </div>
-                    
-                    <div class="auth-section" th:if="${parClaims.context != null and parClaims.context.user != null}">
-                        <div class="auth-section-title">
-                            <i class="bi bi-person"></i> User Information
-                        </div>
-                        <div class="info-grid">
-                            <div class="info-item" th:if="${parClaims.context.user.id != null}">
-                                <div class="info-label">User ID</div>
-                                <div class="info-value" th:text="${parClaims.context.user.id}">user-id</div>
+                            <div class="context-chip" th:if="${parClaims.context.agent != null and parClaims.context.agent.instance != null}">
+                                <i class="bi bi-robot"></i>
+                                <span class="chip-label">Agent</span>
+                                <span th:text="${parClaims.context.agent.instance}">agent-instance</span>
                             </div>
-                        </div>
-                    </div>
-                    
-                    <div class="auth-section" th:if="${parClaims.context != null and parClaims.context.agent != null}">
-                        <div class="auth-section-title">
-                            <i class="bi bi-robot"></i> Agent Information
-                        </div>
-                        <div class="info-grid">
-                            <div class="info-item" th:if="${parClaims.context.agent.instance != null}">
-                                <div class="info-label">Instance</div>
-                                <div class="info-value" th:text="${parClaims.context.agent.instance}">agent-instance</div>
+                            <div class="context-chip" th:if="${parClaims.context.agent != null and parClaims.context.agent.platform != null}">
+                                <i class="bi bi-layers"></i>
+                                <span class="chip-label">Platform</span>
+                                <span th:text="${parClaims.context.agent.platform}">platform</span>
                             </div>
-                            <div class="info-item" th:if="${parClaims.context.agent.platform != null}">
-                                <div class="info-label">Platform</div>
-                                <div class="info-value" th:text="${parClaims.context.agent.platform}">platform</div>
+                            <div class="context-chip" th:if="${parClaims.context.agent != null and parClaims.context.agent.client != null}">
+                                <i class="bi bi-app"></i>
+                                <span class="chip-label">Client</span>
+                                <span th:text="${parClaims.context.agent.client}">client</span>
                             </div>
-                            <div class="info-item" th:if="${parClaims.context.agent.client != null}">
-                                <div class="info-label">Client</div>
-                                <div class="info-value" th:text="${parClaims.context.agent.client}">client</div>
+                            <div class="context-chip" th:if="${parClaims.context.deviceFingerprint != null}">
+                                <i class="bi bi-fingerprint"></i>
+                                <span class="chip-label">Device</span>
+                                <span th:text="${parClaims.context.deviceFingerprint}">device-id</span>
                             </div>
                         </div>
                     </div>
                     
+                    <!-- Identity Binding: collapsible JWT tokens -->
                     <div class="auth-section" th:if="${parClaims.agentUserBindingProposal != null}">
                         <div class="auth-section-title">
-                            <i class="bi bi-link-45deg"></i> Identity Binding Proposal
+                            <i class="bi bi-link-45deg"></i> Identity Binding
                         </div>
                         
                         <div class="collapsible" th:if="${parClaims.agentUserBindingProposal.userIdentityToken != null}">
                             <div class="collapsible-header" onclick="toggleCollapse(this)">
-                                <span><i class="bi bi-key"></i> User Identity Token (JWT)</span>
+                                <span><i class="bi bi-key"></i> User Identity Token</span>
                                 <span class="arrow"><i class="bi bi-chevron-down"></i></span>
                             </div>
                             <div class="collapsible-content">
@@ -689,7 +799,7 @@
                         
                         <div class="collapsible" th:if="${parClaims.agentUserBindingProposal.agentWorkloadToken != null}">
                             <div class="collapsible-header" onclick="toggleCollapse(this)">
-                                <span><i class="bi bi-lightning"></i> Agent Workload Token (JWT)</span>
+                                <span><i class="bi bi-lightning"></i> Agent Workload Token</span>
                                 <span class="arrow"><i class="bi bi-chevron-down"></i></span>
                             </div>
                             <div class="collapsible-content">
@@ -697,29 +807,31 @@
                             </div>
                         </div>
                         
-                        <div class="info-item" th:if="${parClaims.agentUserBindingProposal.deviceFingerprint != null}">
-                            <div class="info-label">Device Fingerprint</div>
-                            <div class="info-value" th:text="${parClaims.agentUserBindingProposal.deviceFingerprint}">device-fingerprint</div>
+                        <div class="context-flow" style="margin-top: var(--space-3);" th:if="${parClaims.agentUserBindingProposal.deviceFingerprint != null}">
+                            <div class="context-chip">
+                                <i class="bi bi-fingerprint"></i>
+                                <span class="chip-label">Device</span>
+                                <span th:text="${parClaims.agentUserBindingProposal.deviceFingerprint}">device-fingerprint</span>
+                            </div>
                         </div>
                     </div>
                     
+                    <!-- Request Metadata: compact key-value rows -->
                     <div class="auth-section" style="margin-bottom: 0;">
                         <div class="auth-section-title">
                             <i class="bi bi-info-circle"></i> Request Metadata
                         </div>
-                        <div class="info-grid">
-                            <div class="info-item" th:if="${parClaims.issuer != null}">
-                                <div class="info-label">Issuer</div>
-                                <div class="info-value" th:text="${parClaims.issuer}">issuer</div>
-                            </div>
-                            <div class="info-item" th:if="${parClaims.subject != null}">
-                                <div class="info-label">Subject</div>
-                                <div class="info-value" th:text="${parClaims.subject}">subject</div>
-                            </div>
-                            <div class="info-item" th:if="${parClaims.jwtId != null}">
-                                <div class="info-label">Request ID</div>
-                                <div class="info-value" th:text="${parClaims.jwtId}">jti</div>
-                            </div>
+                        <div th:if="${parClaims.issuer != null}" class="meta-row">
+                            <span class="meta-key">Issuer</span>
+                            <span class="meta-val" th:text="${parClaims.issuer}">issuer</span>
+                        </div>
+                        <div th:if="${parClaims.subject != null}" class="meta-row">
+                            <span class="meta-key">Subject</span>
+                            <span class="meta-val" th:text="${parClaims.subject}">subject</span>
+                        </div>
+                        <div th:if="${parClaims.jwtId != null}" class="meta-row">
+                            <span class="meta-key">Request ID</span>
+                            <span class="meta-val" th:text="${parClaims.jwtId}">jti</span>
                         </div>
                     </div>
                 </div>

--- a/open-agent-auth-spring-boot-starter/src/test/java/com/alibaba/openagentauth/spring/web/provider/DefaultConsentPageProviderTest.java
+++ b/open-agent-auth-spring-boot-starter/src/test/java/com/alibaba/openagentauth/spring/web/provider/DefaultConsentPageProviderTest.java
@@ -15,10 +15,20 @@
  */
 package com.alibaba.openagentauth.spring.web.provider;
 
+import com.alibaba.openagentauth.core.crypto.jwe.JweDecoder;
 import com.alibaba.openagentauth.core.model.context.OperationRequestContext;
 import com.alibaba.openagentauth.core.model.evidence.Evidence;
 import com.alibaba.openagentauth.core.model.oauth2.par.ParJwtClaims;
 import com.alibaba.openagentauth.core.model.proposal.AgentUserBindingProposal;
+import com.alibaba.openagentauth.core.protocol.vc.jwe.PromptDecryptionService;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
 import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -28,6 +38,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.servlet.ModelAndView;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -45,10 +58,16 @@ class DefaultConsentPageProviderTest {
     @Mock
     private HttpServletRequest request;
 
+    @Mock
+    private JweDecoder jweDecoder;
+
+    private PromptDecryptionService promptDecryptionService;
+
     private DefaultConsentPageProvider provider;
 
     @BeforeEach
     void setUp() {
+        promptDecryptionService = new PromptDecryptionService(jweDecoder, true);
         provider = new DefaultConsentPageProvider();
     }
 
@@ -68,6 +87,24 @@ class DefaultConsentPageProviderTest {
             DefaultConsentPageProvider customProvider = new DefaultConsentPageProvider("custom-consent");
 
             assertThat(customProvider).isNotNull();
+        }
+
+        @Test
+        @DisplayName("Should create provider with PromptDecryptionService")
+        void shouldCreateProviderWithPromptDecryptionService() {
+            DefaultConsentPageProvider providerWithService = 
+                new DefaultConsentPageProvider("consent", "Test IDP", promptDecryptionService);
+
+            assertThat(providerWithService).isNotNull();
+        }
+
+        @Test
+        @DisplayName("Should create provider with null PromptDecryptionService")
+        void shouldCreateProviderWithNullPromptDecryptionService() {
+            DefaultConsentPageProvider providerWithNull = 
+                new DefaultConsentPageProvider("consent", "Test IDP", null);
+
+            assertThat(providerWithNull).isNotNull();
         }
     }
 
@@ -152,6 +189,232 @@ class DefaultConsentPageProviderTest {
             assertThat(mv.getModel()).containsEntry("state", state);
             assertThat(mv.getModel()).containsEntry("scopes", scopes);
             assertThat(mv.getModel()).containsEntry("requestUri", null);
+        }
+
+        @Test
+        @DisplayName("Should render consent page with decoded user prompt from JWT-VC")
+        void shouldRenderConsentPageWithDecodedUserPrompt() {
+            // Setup provider with PromptDecryptionService (enabled=true, but JWT-VC is not JWE format)
+            DefaultConsentPageProvider providerWithService = 
+                new DefaultConsentPageProvider("consent", "Test IDP", promptDecryptionService);
+            
+            String requestUri = "urn:ietf:params:oauth:request_uri:abc123";
+            String subject = "user123";
+            String clientId = "agent-client";
+            String scopes = "openid profile email";
+
+            // JWT-VC is 3-segment (not JWE), so PromptDecryptionService will pass it through
+            String testJwtVc = createTestJwtVcString();
+
+            Evidence evidence = Evidence.builder()
+                    .sourcePromptCredential(testJwtVc)
+                    .build();
+
+            ParJwtClaims parClaims = createTestParClaims(evidence);
+
+            ModelAndView mv = providerWithService.renderConsentPage(
+                request, requestUri, subject, clientId, scopes, parClaims);
+
+            assertThat(mv).isNotNull();
+            assertThat(mv.getViewName()).isEqualTo("consent");
+            assertThat(mv.getModel()).containsKey("decodedCredential");
+            assertThat(mv.getModel()).containsKey("originalUserPrompt");
+            assertThat(mv.getModel()).containsKey("inputChannel");
+            assertThat(mv.getModel()).containsKey("inputTimestamp");
+            assertThat(mv.getModel().get("originalUserPrompt")).isEqualTo("Test user prompt");
+        }
+
+        @Test
+        @DisplayName("Should handle JWT-VC decoding failure gracefully")
+        void shouldHandleJwtVcDecodingFailureGracefully() {
+            // Setup provider with PromptDecryptionService
+            DefaultConsentPageProvider providerWithService = 
+                new DefaultConsentPageProvider("consent", "Test IDP", promptDecryptionService);
+
+            // "invalid-jwt-vc-string" has 0 dots, so PromptDecryptionService passes it through
+            Evidence evidence = Evidence.builder()
+                    .sourcePromptCredential("invalid-jwt-vc-string")
+                    .build();
+
+            ParJwtClaims parClaims = createTestParClaims(evidence);
+
+            // Should not throw exception, but render the page gracefully
+            ModelAndView mv = providerWithService.renderConsentPage(
+                request, "urn:req:1", "user123", "agent-client", "openid profile email", parClaims);
+
+            assertThat(mv).isNotNull();
+            assertThat(mv.getViewName()).isEqualTo("consent");
+            assertThat(mv.getModel()).containsKey("evidence");
+            assertThat(mv.getModel()).doesNotContainKey("decodedCredential");
+            assertThat(mv.getModel()).doesNotContainKey("originalUserPrompt");
+        }
+
+        @Test
+        @DisplayName("Should handle null PromptDecryptionService gracefully")
+        void shouldHandleNullPromptDecryptionServiceGracefully() {
+            // Setup provider with null PromptDecryptionService
+            DefaultConsentPageProvider providerWithNullService = 
+                new DefaultConsentPageProvider("consent", "Test IDP", null);
+            
+            String requestUri = "urn:ietf:params:oauth:request_uri:abc123";
+            String subject = "user123";
+            String clientId = "agent-client";
+            String scopes = "openid profile email";
+
+            // Create a minimal valid JWT-VC string for testing
+            String testJwtVc = createTestJwtVcString();
+
+            // Create evidence with valid JWT-VC
+            Evidence evidence = Evidence.builder()
+                    .sourcePromptCredential(testJwtVc)
+                    .build();
+
+            ParJwtClaims parClaims = createTestParClaims(evidence);
+
+            // Should not throw exception even with null PromptDecryptionService
+            ModelAndView mv = providerWithNullService.renderConsentPage(
+                request, requestUri, subject, clientId, scopes, parClaims);
+
+            assertThat(mv).isNotNull();
+            assertThat(mv.getViewName()).isEqualTo("consent");
+            // The model should still contain the decoded credential
+            // because the JWT-VC is not encrypted, so decryption is not needed
+            assertThat(mv.getModel()).containsKey("decodedCredential");
+            assertThat(mv.getModel()).containsKey("originalUserPrompt");
+        }
+
+        @Test
+        @DisplayName("Should decrypt JWE-encrypted prompt inside JWT-VC credential subject")
+        void shouldDecryptJweEncryptedPromptInsideJwtVc() throws Exception {
+            DefaultConsentPageProvider providerWithService =
+                new DefaultConsentPageProvider("consent", "Test IDP", promptDecryptionService);
+
+            // Build a JWT-VC whose credentialSubject.prompt is a JWE string (5 dot-separated segments)
+            String jweEncryptedPrompt = "eyJhbGciOiJSU0EtT0FFUC0yNTYiLCJlbmMiOiJBMjU2R0NNIn0"
+                    + ".encryptedKey.iv.ciphertext.tag";
+            String testJwtVc = createTestJwtVcStringWithPrompt(jweEncryptedPrompt);
+
+            Evidence evidence = Evidence.builder()
+                    .sourcePromptCredential(testJwtVc)
+                    .build();
+            ParJwtClaims parClaims = createTestParClaims(evidence);
+
+            // Inner decryption: the prompt field IS JWE (4 dots), so jweDecoder will be called
+            when(jweDecoder.decryptToString(jweEncryptedPrompt))
+                    .thenReturn("buy some programming books");
+
+            ModelAndView mv = providerWithService.renderConsentPage(
+                    request, "urn:req:1", "user1", "client1", "openid", parClaims);
+
+            assertThat(mv.getModel().get("originalUserPrompt"))
+                    .isEqualTo("buy some programming books");
+        }
+
+        @Test
+        @DisplayName("Should not set originalUserPrompt when inner JWE decryption fails")
+        void shouldNotSetOriginalUserPromptWhenInnerJweDecryptionFails() throws Exception {
+            DefaultConsentPageProvider providerWithService =
+                new DefaultConsentPageProvider("consent", "Test IDP", promptDecryptionService);
+
+            String jweEncryptedPrompt = "eyJhbGciOiJSU0EtT0FFUC0yNTYiLCJlbmMiOiJBMjU2R0NNIn0"
+                    + ".encryptedKey.iv.ciphertext.tag";
+            String testJwtVc = createTestJwtVcStringWithPrompt(jweEncryptedPrompt);
+
+            Evidence evidence = Evidence.builder()
+                    .sourcePromptCredential(testJwtVc)
+                    .build();
+            ParJwtClaims parClaims = createTestParClaims(evidence);
+
+            // Inner: jweDecoder throws, so tryDecryptOrPassthrough returns the JWE unchanged
+            when(jweDecoder.decryptToString(jweEncryptedPrompt))
+                    .thenThrow(new JOSEException("Decryption key not found"));
+
+            ModelAndView mv = providerWithService.renderConsentPage(
+                    request, "urn:req:1", "user1", "client1", "openid", parClaims);
+
+            // The prompt is still JWE after failed decryption, so originalUserPrompt should NOT be set
+            assertThat(mv.getModel()).doesNotContainKey("originalUserPrompt");
+        }
+
+        @Test
+        @DisplayName("Should format ISO 8601 timestamp into human-readable format")
+        void shouldFormatTimestampIntoHumanReadableFormat() {
+            DefaultConsentPageProvider providerWithNullService =
+                new DefaultConsentPageProvider("consent", "Test IDP", null);
+
+            // JWT-VC with a known ISO timestamp
+            String testJwtVc = createTestJwtVcString(); // timestamp = "2024-01-01T00:00:00Z"
+
+            Evidence evidence = Evidence.builder()
+                    .sourcePromptCredential(testJwtVc)
+                    .build();
+            ParJwtClaims parClaims = createTestParClaims(evidence);
+
+            ModelAndView mv = providerWithNullService.renderConsentPage(
+                    request, "urn:req:1", "user1", "client1", "openid", parClaims);
+
+            // The timestamp "2024-01-01T00:00:00Z" should be formatted
+            String formattedTimestamp = (String) mv.getModel().get("inputTimestamp");
+            assertThat(formattedTimestamp).isNotNull();
+            assertThat(formattedTimestamp).contains("Jan");
+            assertThat(formattedTimestamp).contains("2024");
+            assertThat(formattedTimestamp).contains("UTC");
+        }
+
+        @Test
+        @DisplayName("Should handle null evidence sourcePromptCredential gracefully")
+        void shouldHandleNullSourcePromptCredentialGracefully() {
+            Evidence evidence = Evidence.builder()
+                    .sourcePromptCredential(null)
+                    .build();
+            ParJwtClaims parClaims = createTestParClaims(evidence);
+
+            ModelAndView mv = provider.renderConsentPage(
+                    request, "urn:req:1", "user1", "client1", "openid", parClaims);
+
+            assertThat(mv).isNotNull();
+            assertThat(mv.getModel()).doesNotContainKey("decodedCredential");
+            assertThat(mv.getModel()).doesNotContainKey("originalUserPrompt");
+        }
+
+        @Test
+        @DisplayName("Should handle empty evidence sourcePromptCredential gracefully")
+        void shouldHandleEmptySourcePromptCredentialGracefully() {
+            Evidence evidence = Evidence.builder()
+                    .sourcePromptCredential("")
+                    .build();
+            ParJwtClaims parClaims = createTestParClaims(evidence);
+
+            ModelAndView mv = provider.renderConsentPage(
+                    request, "urn:req:1", "user1", "client1", "openid", parClaims);
+
+            assertThat(mv).isNotNull();
+            assertThat(mv.getModel()).doesNotContainKey("decodedCredential");
+            assertThat(mv.getModel()).doesNotContainKey("originalUserPrompt");
+        }
+
+        @Test
+        @DisplayName("Should skip decoding when sourcePromptCredential is still JWE after decryption attempt")
+        void shouldSkipDecodingWhenStillJweAfterDecryptionAttempt() throws Exception {
+            DefaultConsentPageProvider providerWithService =
+                new DefaultConsentPageProvider("consent", "Test IDP", promptDecryptionService);
+
+            // A JWE string (5 dot-separated segments)
+            String jweString = "header.encryptedKey.iv.ciphertext.tag";
+
+            Evidence evidence = Evidence.builder()
+                    .sourcePromptCredential(jweString)
+                    .build();
+            ParJwtClaims parClaims = createTestParClaims(evidence);
+
+            // jweDecoder returns the same JWE string (simulating decryption that yields another JWE)
+            when(jweDecoder.decryptToString(jweString)).thenReturn(jweString);
+
+            ModelAndView mv = providerWithService.renderConsentPage(
+                    request, "urn:req:1", "user1", "client1", "openid", parClaims);
+
+            assertThat(mv.getModel()).doesNotContainKey("decodedCredential");
+            assertThat(mv.getModel()).doesNotContainKey("originalUserPrompt");
         }
     }
 
@@ -272,5 +535,92 @@ class DefaultConsentPageProviderTest {
                 .context(context)
                 .state("state-123")
                 .build();
+    }
+
+    private ParJwtClaims createTestParClaims(Evidence evidence) {
+        // Create operation proposal
+        String operationProposal = "package agent\nallow {\n  input.operationType == \"read\"\n}";
+        
+        // Create context
+        OperationRequestContext.UserContext userContext = OperationRequestContext.UserContext.builder()
+                .id("user123")
+                .build();
+        
+        OperationRequestContext.AgentContext agentContext = OperationRequestContext.AgentContext.builder()
+                .instance("agent-instance-1")
+                .platform("web")
+                .client("agent-client")
+                .build();
+        
+        OperationRequestContext context = OperationRequestContext.builder()
+                .channel("web")
+                .deviceFingerprint("device-123")
+                .language("en-US")
+                .user(userContext)
+                .agent(agentContext)
+                .build();
+        
+        // Create binding proposal (using minimal constructor)
+        AgentUserBindingProposal bindingProposal = new AgentUserBindingProposal(
+                "user-id-token",
+                "agent-workload-token",
+                "device-fingerprint"
+        );
+        
+        // Create PAR claims
+        return ParJwtClaims.builder()
+                .issuer("https://client.example.com")
+                .subject("user123")
+                .audience(java.util.Arrays.asList("https://as.example.com"))
+                .issueTime(new java.util.Date())
+                .expirationTime(new java.util.Date(System.currentTimeMillis() + 3600000))
+                .jwtId("jti-123")
+                .evidence(evidence)
+                .agentUserBindingProposal(bindingProposal)
+                .operationProposal(operationProposal)
+                .context(context)
+                .state("state-123")
+                .build();
+    }
+
+    /**
+     * Creates a signed JWT-VC string for testing.
+     * Uses RS256 signing so that SignedJWT.parse() in JwtVcDecoder.decode() can parse it.
+     */
+    private String createTestJwtVcString() {
+        return createTestJwtVcStringWithPrompt("Test user prompt");
+    }
+
+    /**
+     * Creates a signed JWT-VC string with a custom prompt value in the credentialSubject.
+     * Used to test scenarios where the prompt field itself is JWE-encrypted.
+     */
+    private String createTestJwtVcStringWithPrompt(String promptValue) {
+        try {
+            RSAKey rsaKey = new RSAKeyGenerator(2048)
+                    .keyID("test-vc-key")
+                    .generate();
+
+            Map<String, Object> credentialSubject = new LinkedHashMap<>();
+            credentialSubject.put("type", "UserInputEvidence");
+            credentialSubject.put("prompt", promptValue);
+            credentialSubject.put("timestamp", "2024-01-01T00:00:00Z");
+            credentialSubject.put("channel", "web");
+
+            JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
+                    .subject("test-sub")
+                    .claim("credentialSubject", credentialSubject)
+                    .build();
+
+            JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.RS256)
+                    .keyID(rsaKey.getKeyID())
+                    .build();
+
+            SignedJWT signedJWT = new SignedJWT(header, claimsSet);
+            signedJWT.sign(new RSASSASigner(rsaKey));
+            return signedJWT.serialize();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create test JWT-VC", e);
+        }
     }
 }


### PR DESCRIPTION
## Description

This PR introduces three major improvements to the Open Agent Auth project:

1. **Consent Page JWE Decryption Fix**: Resolved the issue where the AOA consent page displayed raw JWE-encrypted strings instead of human-readable user prompts. The `DefaultConsentPageProvider` now properly decrypts JWE-wrapped prompts inside JWT-VC credentials before rendering them on the consent page.

2. **Audit Operation Text Rendering**: Added a new audit subsystem (`core/audit`) that provides human-readable text rendering for agent operation authorization events. This includes the `OperationTextRenderer` strategy interface, `PatternBasedOperationTextRenderer` implementation, and supporting model classes (`OperationTextRenderContext`, `OperationTextRenderResult`, `SemanticExpansionLevel`).

3. **Consent Page UX Overhaul**: Redesigned the consent page layout with improved information density, a distinctive quote-style treatment for user original input, and consolidated module sections for a cleaner visual hierarchy.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [x] Code refactoring
- [x] Test additions or updates
- [ ] Other (please describe)

## Changes Made

### Core Module (`open-agent-auth-core`)
- **New `audit` package**: Introduced `OperationTextRenderer` interface (Strategy pattern) for rendering human-readable operation authorization text
- **`PatternBasedOperationTextRenderer`**: Pattern-based implementation that composes operation text from prompt, policy proposal, request context (channel/platform), and token expiration
- **`OperationTextRenderContext`**: Immutable context object (Builder pattern) carrying all rendering inputs with proper `equals`/`hashCode`/`toString`
- **`OperationTextRenderResult`**: Immutable result with rendered text and semantic expansion level, including static factory methods (`withNoExpansion`, `withLowExpansion`, `withMediumExpansion`)
- **`SemanticExpansionLevel`**: Enum representing how much the rendered text semantically expands beyond the original input (`NONE`, `LOW`, `MEDIUM`, `HIGH`)
- **`DefaultAoatTokenGenerator`**: Refactored token generation logic

### Spring Boot Starter Module (`open-agent-auth-spring-boot-starter`)
- **`DefaultConsentPageProvider`**: Added JWE decryption for `credentialSubject.prompt` field inside JWT-VC credentials, with graceful fallback when decryption keys are unavailable
- **`AuthorizationServerAutoConfiguration`**: Updated auto-configuration to wire `PromptDecryptionService` into the consent page provider
- **`aoa_consent.html`**: Redesigned consent page with quote-style user prompt display, consolidated layout sections, and improved CSS styling

### Tests
- **`PatternBasedOperationTextRendererTest`**: Comprehensive test suite (64 test cases) covering rendering logic, truncation, context appending, expiration formatting, semantic expansion levels, result equality, context builder, enum behavior, static factories, null validation, and `equals`/`hashCode`/`toString` contracts
- **`DefaultConsentPageProviderTest`**: Extended test coverage for JWT-VC decoding, JWE prompt decryption, and edge cases (null credentials, empty prompts, undecryptable JWE)
- **`DefaultAoatTokenGeneratorTest`**: Updated tests for refactored token generation

### Documentation
- Added comprehensive JavaDoc annotations to all audit module classes, including field-level, method-level, and class-level documentation

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed
- [x] All existing tests pass

**Test Instructions:**
```bash
# Run audit module tests
mvn test -pl open-agent-auth-core -Dtest="PatternBasedOperationTextRendererTest"

# Run consent page provider tests
mvn test -pl open-agent-auth-spring-boot-starter -Dtest="DefaultConsentPageProviderTest"

# Run all tests
mvn test
```

## Checklist
- [x] Code follows [coding standards](CONTRIBUTING.md#coding-standards)
- [x] Self-review performed
- [x] Documentation updated
- [x] No new warnings
- [x] Tests added/updated
- [x] All tests pass locally
- [ ] [CHANGELOG.md](CHANGELOG.md) updated

## Breaking Changes
No breaking changes. All new functionality is additive and backward-compatible.

## Additional Context

### Architecture Decisions
- **Strategy Pattern** for `OperationTextRenderer`: Allows pluggable rendering implementations without modifying consumers
- **Builder Pattern** for `OperationTextRenderContext`: Provides a clean, readable API for constructing complex context objects with many optional fields
- **Immutable Value Objects**: Both `OperationTextRenderResult` and `OperationTextRenderContext` are designed as immutable objects with proper `equals`/`hashCode` contracts, ensuring thread safety and predictable behavior
- **Graceful Degradation**: JWE decryption in the consent page falls through to raw display when decryption keys are unavailable, rather than failing the entire page

### Files Changed (12 files, +2779 / -132 lines)
| File | Change |
|------|--------|
| `core/audit/api/OperationTextRenderer.java` | New strategy interface |
| `core/audit/impl/PatternBasedOperationTextRenderer.java` | New pattern-based renderer |
| `core/audit/model/OperationTextRenderContext.java` | New rendering context model |
| `core/audit/model/OperationTextRenderResult.java` | New rendering result model |
| `core/audit/model/SemanticExpansionLevel.java` | New semantic expansion enum |
| `core/protocol/.../DefaultAoatTokenGenerator.java` | Refactored token generation |
| `core/.../PatternBasedOperationTextRendererTest.java` | 64 test cases for audit module |
| `core/.../DefaultAoatTokenGeneratorTest.java` | Updated token generator tests |
| `spring/.../AuthorizationServerAutoConfiguration.java` | Auto-config wiring update |
| `spring/.../DefaultConsentPageProvider.java` | JWE decryption + consent logic |
| `spring/.../aoa_consent.html` | Consent page UX redesign |
| `spring/.../DefaultConsentPageProviderTest.java` | Extended consent page tests |