### PR TITLE
feat(aoa): add LLM-based operation text rendering to the AOA consent page and improve consent page UX

### DIFF
--- a/open-agent-auth-samples/sample-authorization-server/pom.xml
+++ b/open-agent-auth-samples/sample-authorization-server/pom.xml
@@ -34,10 +34,23 @@
             <artifactId>open-agent-auth-spring-boot-starter</artifactId>
         </dependency>
 
+        <!-- Qwen SDK for LLM-based operation text rendering -->
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>qwencode-sdk</artifactId>
+            <version>0.0.1-alpha</version>
+        </dependency>
+
         <!-- Testing -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>5.2.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/open-agent-auth-samples/sample-authorization-server/src/main/java/com/alibaba/openagentauth/sample/authz/config/LlmRendererConfiguration.java
+++ b/open-agent-auth-samples/sample-authorization-server/src/main/java/com/alibaba/openagentauth/sample/authz/config/LlmRendererConfiguration.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.openagentauth.sample.authz.config;
+
+import com.alibaba.openagentauth.core.audit.api.OperationTextRenderer;
+import com.alibaba.openagentauth.sample.authz.renderer.QwenLlmOperationTextRenderer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration for the LLM-based operation text renderer in the sample Authorization Server.
+ * <p>
+ * This configuration registers a {@link QwenLlmOperationTextRenderer} bean that uses
+ * Alibaba Cloud's Qwen model via qwencode-sdk to generate human-readable operation
+ * descriptions. It overrides the default {@code PatternBasedOperationTextRenderer}
+ * provided by the framework's auto-configuration.
+ * </p>
+ * <p>
+ * The SDK usage is consistent with the sample-agent's {@code QwenClientWrapper},
+ * using the same qwencode-sdk dependency and similar configuration patterns
+ * (model name, timeout).
+ * </p>
+ * <p>
+ * The renderer is conditionally enabled via the {@code sample.llm-renderer.enabled} property.
+ * When disabled, the framework falls back to the default pattern-based renderer.
+ * </p>
+ *
+ * @since 1.0
+ */
+@Configuration
+@ConditionalOnProperty(name = "sample.llm-renderer.enabled", havingValue = "true")
+public class LlmRendererConfiguration {
+
+    private static final Logger logger = LoggerFactory.getLogger(LlmRendererConfiguration.class);
+
+    /**
+     * Creates a Qwen LLM-based operation text renderer.
+     * <p>
+     * The model name defaults to {@code qwen3-coder-flash} (consistent with sample-agent)
+     * but can be overridden via {@code sample.llm-renderer.model}.
+     * The timeout defaults to 120 seconds but can be overridden via
+     * {@code sample.llm-renderer.timeout}.
+     * </p>
+     *
+     * @param modelName the Qwen model name
+     * @param timeoutSeconds the timeout in seconds for LLM calls
+     * @return a configured QwenLlmOperationTextRenderer instance
+     */
+    @Bean
+    public OperationTextRenderer operationTextRenderer(
+            @Value("${sample.llm-renderer.model:qwen3-coder-flash}") String modelName,
+            @Value("${sample.llm-renderer.timeout:120}") long timeoutSeconds) {
+
+        logger.info("Creating QwenLlmOperationTextRenderer with model: {}, timeout: {}s",
+                modelName, timeoutSeconds);
+        return new QwenLlmOperationTextRenderer(modelName, timeoutSeconds);
+    }
+}

--- a/open-agent-auth-samples/sample-authorization-server/src/main/java/com/alibaba/openagentauth/sample/authz/renderer/QwenLlmOperationTextRenderer.java
+++ b/open-agent-auth-samples/sample-authorization-server/src/main/java/com/alibaba/openagentauth/sample/authz/renderer/QwenLlmOperationTextRenderer.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.openagentauth.sample.authz.renderer;
+
+import com.alibaba.openagentauth.core.audit.api.OperationTextRenderer;
+import com.alibaba.openagentauth.core.audit.model.OperationTextRenderContext;
+import com.alibaba.openagentauth.core.audit.model.OperationTextRenderResult;
+import com.alibaba.openagentauth.core.audit.model.SemanticExpansionLevel;
+import com.alibaba.openagentauth.core.model.context.OperationRequestContext;
+import com.alibaba.qwen.code.cli.QwenCodeCli;
+import com.alibaba.qwen.code.cli.protocol.data.AssistantContent;
+import com.alibaba.qwen.code.cli.protocol.data.PermissionMode;
+import com.alibaba.qwen.code.cli.session.Session;
+import com.alibaba.qwen.code.cli.session.event.consumers.AssistantContentSimpleConsumers;
+import com.alibaba.qwen.code.cli.transport.TransportOptions;
+import com.alibaba.qwen.code.cli.utils.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * LLM-based implementation of {@link OperationTextRenderer} using Alibaba Cloud's Qwen model
+ * via the qwencode-sdk.
+ * <p>
+ * This renderer leverages the Qwen large language model to intelligently interpret Rego policies
+ * and generate natural-language descriptions of authorized operations. Compared to the
+ * {@link com.alibaba.openagentauth.core.audit.impl.PatternBasedOperationTextRenderer},
+ * this implementation produces more natural, context-aware, and user-friendly descriptions.
+ * </p>
+ * <p>
+ * The SDK usage is consistent with the sample-agent's {@code QwenClientWrapper}, using
+ * {@link QwenCodeCli#simpleQuery(String, TransportOptions, AssistantContentSimpleConsumers)}
+ * for LLM interaction.
+ * </p>
+ * <p>
+ * According to draft-liu-agent-operation-authorization-01 Section 4, the rendered text serves
+ * the Semantic Audit Trail by documenting how the system interpreted the user's input into
+ * a concrete operation description.
+ * </p>
+ *
+ * @see OperationTextRenderer
+ * @since 1.0
+ */
+public class QwenLlmOperationTextRenderer implements OperationTextRenderer {
+
+    private static final Logger logger = LoggerFactory.getLogger(QwenLlmOperationTextRenderer.class);
+
+    private static final String SYSTEM_INSTRUCTION = """
+            You are an authorization consent page assistant. Translate a machine-readable Rego policy \
+            into a concise, scannable explanation for a non-technical user.
+            
+            Output MUST use this exact structure:
+            
+            What this authorizes: [ONE sentence. State the action, the target resource, and any scope \
+            in a single concise sentence. Do NOT repeat or paraphrase the same information twice.]
+            
+            Key constraints: [Bullet each REAL constraint from the policy, prefixed with "- ". \
+            Only list limits that ARE explicitly present (e.g., spending caps, time windows, category \
+            restrictions, rate limits, geographic bounds). NEVER list the absence of a constraint \
+            (e.g., do NOT write "No spending cap is set"). If no constraints exist beyond what is \
+            already stated above, omit this section entirely.]
+            
+            What this means for you: [ONE sentence. State what the agent can do after approval. \
+            Only mention token expiration if an explicit expiration time is provided in the input.]
+            
+            Rules:
+            1. Be extremely concise. The user should grasp the meaning within 5 seconds of reading.
+            2. No greetings, no markdown, no extra commentary.
+            3. Use plain language. Avoid jargon like "Rego", "OPA", "policy", "predicate".
+            4. Never repeat information across sections. Each section adds NEW information only.
+            5. Prefer concrete terms: "search for books" over "perform search operations".
+            6. Respond in English.
+            """;
+
+    private final String modelName;
+    private final long timeoutSeconds;
+
+    /**
+     * Constructs a new QwenLlmOperationTextRenderer with the specified model name and timeout.
+     *
+     * @param modelName the Qwen model name to use (e.g., "qwen3-coder-flash", "qwen-plus")
+     * @param timeoutSeconds the timeout in seconds for LLM calls
+     */
+    public QwenLlmOperationTextRenderer(String modelName, long timeoutSeconds) {
+        this.modelName = Objects.requireNonNull(modelName, "Model name must not be null");
+        this.timeoutSeconds = timeoutSeconds;
+        logger.info("Initialized QwenLlmOperationTextRenderer with model: {}, timeout: {}s",
+                modelName, timeoutSeconds);
+    }
+
+    @Override
+    public OperationTextRenderResult render(OperationTextRenderContext context) {
+        logger.debug("Rendering operation text using Qwen LLM (model: {})", modelName);
+
+        String prompt = buildPrompt(context);
+
+        try {
+            String renderedText = callQwenModel(prompt);
+            SemanticExpansionLevel expansionLevel = determineExpansionLevel(context);
+
+            logger.info("Qwen LLM rendered operation text: '{}' (expansion: {})",
+                    renderedText, expansionLevel);
+            return new OperationTextRenderResult(renderedText, expansionLevel);
+        } catch (Exception exception) {
+            logger.warn("Qwen LLM call failed, falling back to basic rendering. Error: {}",
+                    exception.getMessage());
+            return buildFallbackResult(context);
+        }
+    }
+
+    /**
+     * Builds the full prompt from the rendering context.
+     * <p>
+     * Constructs a structured prompt that includes the system instruction, Rego policy,
+     * original user prompt, and contextual information to help the LLM produce an accurate
+     * description.
+     * </p>
+     */
+    private String buildPrompt(OperationTextRenderContext context) {
+        StringBuilder prompt = new StringBuilder();
+
+        prompt.append(SYSTEM_INSTRUCTION).append("\n\n");
+        prompt.append("--- Input ---\n\n");
+
+        String operationProposal = context.getOperationProposal();
+        if (operationProposal != null && !operationProposal.isEmpty()) {
+            prompt.append("Rego Policy:\n").append(operationProposal).append("\n\n");
+        }
+
+        String originalPrompt = context.getOriginalPrompt();
+        if (originalPrompt != null && !originalPrompt.isEmpty()) {
+            prompt.append("User's Original Request: \"").append(originalPrompt).append("\"\n\n");
+        }
+
+        OperationRequestContext requestContext = context.getRequestContext();
+        if (requestContext != null) {
+            prompt.append("Context:\n");
+            if (requestContext.getChannel() != null) {
+                prompt.append("- Channel: ").append(requestContext.getChannel()).append("\n");
+            }
+            if (requestContext.getLanguage() != null) {
+                prompt.append("- Language: ").append(requestContext.getLanguage()).append("\n");
+            }
+            if (requestContext.getAgent() != null) {
+                if (requestContext.getAgent().getPlatform() != null) {
+                    prompt.append("- Platform: ").append(requestContext.getAgent().getPlatform()).append("\n");
+                }
+                if (requestContext.getAgent().getClient() != null) {
+                    prompt.append("- Client: ").append(requestContext.getAgent().getClient()).append("\n");
+                }
+            }
+        }
+
+        if (context.getTokenExpiration() != null) {
+            prompt.append("\nAuthorization valid until: ").append(context.getTokenExpiration()).append("\n");
+        }
+
+        prompt.append("\nPlease provide the three-part explanation (What this authorizes / Key constraints / What this means for you).");
+        return prompt.toString();
+    }
+
+    /**
+     * Calls the Qwen model via qwencode-sdk and returns the generated text.
+     * <p>
+     * Uses {@link QwenCodeCli#simpleQuery(String, TransportOptions, AssistantContentSimpleConsumers)}
+     * consistent with the sample-agent's {@code QwenClientWrapper} implementation.
+     * </p>
+     */
+    private String callQwenModel(String prompt) {
+        TransportOptions options = new TransportOptions()
+                .setModel(modelName)
+                .setPermissionMode(PermissionMode.AUTO_EDIT)
+                .setCwd("./")
+                .setTurnTimeout(new Timeout(timeoutSeconds, TimeUnit.SECONDS))
+                .setMessageTimeout(new Timeout(timeoutSeconds, TimeUnit.SECONDS));
+
+        StringBuilder accumulatedText = new StringBuilder();
+        AtomicReference<Exception> errorRef = new AtomicReference<>();
+
+        AssistantContentSimpleConsumers consumers = new AssistantContentSimpleConsumers() {
+            @Override
+            public void onText(Session session, AssistantContent.TextAssistantContent textContent) {
+                String text = textContent.getText();
+                if (text != null) {
+                    accumulatedText.append(text);
+                }
+            }
+
+            @Override
+            public void onToolUse(Session session, AssistantContent.ToolUseAssistantContent toolUseContent) {
+                logger.debug("Ignoring unexpected tool use in operation text rendering");
+            }
+
+            @Override
+            public void onToolResult(Session session, AssistantContent.ToolResultAssistantContent toolResultContent) {
+                logger.debug("Ignoring unexpected tool result in operation text rendering");
+            }
+        };
+
+        try {
+            QwenCodeCli.simpleQuery(prompt, options, consumers);
+        } catch (Exception exception) {
+            errorRef.set(exception);
+        }
+
+        if (errorRef.get() != null) {
+            throw new RuntimeException("Qwen model call failed: " + errorRef.get().getMessage(), errorRef.get());
+        }
+
+        String result = accumulatedText.toString().strip();
+        if (result.isEmpty()) {
+            throw new IllegalStateException("Qwen model returned empty content");
+        }
+
+        return result;
+    }
+
+    /**
+     * Determines the semantic expansion level based on the available context.
+     * <p>
+     * LLM-based rendering always involves interpretation, so the minimum level is MEDIUM.
+     * When the original prompt is absent and only the Rego policy is available,
+     * the expansion level is HIGH since the LLM must infer user intent entirely.
+     * </p>
+     */
+    private SemanticExpansionLevel determineExpansionLevel(OperationTextRenderContext context) {
+        if (context.getOriginalPrompt() == null || context.getOriginalPrompt().isEmpty()) {
+            return SemanticExpansionLevel.HIGH;
+        }
+        return SemanticExpansionLevel.MEDIUM;
+    }
+
+    /**
+     * Builds a fallback result when the LLM call fails.
+     * Falls back to a simple pattern-based description.
+     */
+    private OperationTextRenderResult buildFallbackResult(OperationTextRenderContext context) {
+        String originalPrompt = context.getOriginalPrompt();
+        if (originalPrompt != null && !originalPrompt.isEmpty()) {
+            return OperationTextRenderResult.withLowExpansion("Authorized: " + originalPrompt);
+        }
+
+        String operationProposal = context.getOperationProposal();
+        if (operationProposal != null && !operationProposal.isEmpty()) {
+            String preview = operationProposal.length() > 80
+                    ? operationProposal.substring(0, 80) + "..."
+                    : operationProposal;
+            return OperationTextRenderResult.withLowExpansion(
+                    "Authorized agent operation per policy: " + preview);
+        }
+
+        return OperationTextRenderResult.withNoExpansion("Authorized agent operation");
+    }
+}

--- a/open-agent-auth-samples/sample-authorization-server/src/main/resources/application.yml
+++ b/open-agent-auth-samples/sample-authorization-server/src/main/resources/application.yml
@@ -84,6 +84,17 @@ open-agent-auth:
       instance-id: authorization-server-1
       issuer: http://localhost:8085
   
+# LLM-based operation text renderer configuration (uses qwencode-sdk, consistent with sample-agent)
+# Set 'enabled: true' to use Qwen LLM for generating human-readable operation descriptions
+# on the consent page. When disabled, the framework uses the default PatternBasedOperationTextRenderer.
+sample:
+  llm-renderer:
+    enabled: true
+    # Qwen model to use. Consistent with sample-agent's default model.
+    model: qwen3-coder-flash
+    # Timeout in seconds for LLM calls
+    timeout: 120
+
 logging:
   level:
     com.alibaba.openagentauth: DEBUG

--- a/open-agent-auth-samples/sample-authorization-server/src/test/java/com/alibaba/openagentauth/sample/authz/config/LlmRendererConfigurationTest.java
+++ b/open-agent-auth-samples/sample-authorization-server/src/test/java/com/alibaba/openagentauth/sample/authz/config/LlmRendererConfigurationTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.openagentauth.sample.authz.config;
+
+import com.alibaba.openagentauth.core.audit.api.OperationTextRenderer;
+import com.alibaba.openagentauth.sample.authz.renderer.QwenLlmOperationTextRenderer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link LlmRendererConfiguration}.
+ * <p>
+ * Verifies that the configuration correctly creates an {@link OperationTextRenderer} bean
+ * with the expected model name and timeout parameters.
+ * </p>
+ */
+@DisplayName("LlmRendererConfiguration Tests")
+class LlmRendererConfigurationTest {
+
+    @Test
+    @DisplayName("Should create OperationTextRenderer with default model and timeout")
+    void shouldCreateOperationTextRendererWithDefaults() {
+        LlmRendererConfiguration configuration = new LlmRendererConfiguration();
+
+        OperationTextRenderer renderer = configuration.operationTextRenderer(
+                "qwen3-coder-flash", 120);
+
+        assertThat(renderer).isNotNull();
+        assertThat(renderer).isInstanceOf(QwenLlmOperationTextRenderer.class);
+    }
+
+    @Test
+    @DisplayName("Should create OperationTextRenderer with custom model name")
+    void shouldCreateOperationTextRendererWithCustomModel() {
+        LlmRendererConfiguration configuration = new LlmRendererConfiguration();
+
+        OperationTextRenderer renderer = configuration.operationTextRenderer(
+                "qwen-plus", 60);
+
+        assertThat(renderer).isNotNull();
+        assertThat(renderer).isInstanceOf(QwenLlmOperationTextRenderer.class);
+    }
+
+    @Test
+    @DisplayName("Should create OperationTextRenderer with custom timeout")
+    void shouldCreateOperationTextRendererWithCustomTimeout() {
+        LlmRendererConfiguration configuration = new LlmRendererConfiguration();
+
+        OperationTextRenderer renderer = configuration.operationTextRenderer(
+                "qwen3-coder-flash", 300);
+
+        assertThat(renderer).isNotNull();
+        assertThat(renderer).isInstanceOf(QwenLlmOperationTextRenderer.class);
+    }
+}

--- a/open-agent-auth-samples/sample-authorization-server/src/test/java/com/alibaba/openagentauth/sample/authz/renderer/QwenLlmOperationTextRendererTest.java
+++ b/open-agent-auth-samples/sample-authorization-server/src/test/java/com/alibaba/openagentauth/sample/authz/renderer/QwenLlmOperationTextRendererTest.java
@@ -1,0 +1,430 @@
+/*
+ * Copyright 2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.openagentauth.sample.authz.renderer;
+
+import com.alibaba.openagentauth.core.audit.model.OperationTextRenderContext;
+import com.alibaba.openagentauth.core.audit.model.OperationTextRenderResult;
+import com.alibaba.openagentauth.core.audit.model.SemanticExpansionLevel;
+import com.alibaba.openagentauth.core.model.context.OperationRequestContext;
+import com.alibaba.qwen.code.cli.QwenCodeCli;
+import com.alibaba.qwen.code.cli.session.event.consumers.AssistantContentSimpleConsumers;
+import com.alibaba.qwen.code.cli.transport.TransportOptions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+
+/**
+ * Unit tests for {@link QwenLlmOperationTextRenderer}.
+ * <p>
+ * Uses {@code mockStatic} to mock the static {@link QwenCodeCli#simpleQuery} method,
+ * avoiding actual LLM calls during testing.
+ * </p>
+ */
+@DisplayName("QwenLlmOperationTextRenderer Tests")
+class QwenLlmOperationTextRendererTest {
+
+    private static final String TEST_MODEL = "qwen3-coder-flash";
+    private static final long TEST_TIMEOUT = 30;
+
+    @Nested
+    @DisplayName("Constructor Tests")
+    class ConstructorTests {
+
+        @Test
+        @DisplayName("Should create renderer with valid parameters")
+        void shouldCreateRendererWithValidParameters() {
+            QwenLlmOperationTextRenderer renderer = new QwenLlmOperationTextRenderer(TEST_MODEL, TEST_TIMEOUT);
+            assertThat(renderer).isNotNull();
+        }
+
+        @Test
+        @DisplayName("Should reject null model name")
+        void shouldRejectNullModelName() {
+            assertThatThrownBy(() -> new QwenLlmOperationTextRenderer(null, TEST_TIMEOUT))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("Model name must not be null");
+        }
+    }
+
+    @Nested
+    @DisplayName("Render Tests")
+    class RenderTests {
+
+        @Test
+        @DisplayName("Should render operation text successfully via LLM")
+        void shouldRenderOperationTextSuccessfully() {
+            QwenLlmOperationTextRenderer renderer = new QwenLlmOperationTextRenderer(TEST_MODEL, TEST_TIMEOUT);
+
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .operationProposal("package agent\nallow { input.action == \"search\" }")
+                    .originalPrompt("Search for programming books")
+                    .build();
+
+            try (MockedStatic<QwenCodeCli> mockedCli = mockStatic(QwenCodeCli.class)) {
+                mockedCli.when(() -> QwenCodeCli.simpleQuery(
+                        anyString(), any(TransportOptions.class), any(AssistantContentSimpleConsumers.class)))
+                        .thenAnswer(invocation -> {
+                            AssistantContentSimpleConsumers consumers = invocation.getArgument(2);
+                            // Simulate text callback via mock AssistantContent
+                            simulateTextResponse(consumers, "What this authorizes: The agent can search for books.");
+                            return null;
+                        });
+
+                OperationTextRenderResult result = renderer.render(context);
+
+                assertThat(result).isNotNull();
+                assertThat(result.getRenderedText()).isEqualTo("What this authorizes: The agent can search for books.");
+                assertThat(result.getSemanticExpansionLevel()).isEqualTo(SemanticExpansionLevel.MEDIUM);
+            }
+        }
+
+        @Test
+        @DisplayName("Should return HIGH expansion level when original prompt is absent")
+        void shouldReturnHighExpansionWhenOriginalPromptAbsent() {
+            QwenLlmOperationTextRenderer renderer = new QwenLlmOperationTextRenderer(TEST_MODEL, TEST_TIMEOUT);
+
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .operationProposal("package agent\nallow { input.action == \"search\" }")
+                    .build();
+
+            try (MockedStatic<QwenCodeCli> mockedCli = mockStatic(QwenCodeCli.class)) {
+                mockedCli.when(() -> QwenCodeCli.simpleQuery(
+                        anyString(), any(TransportOptions.class), any(AssistantContentSimpleConsumers.class)))
+                        .thenAnswer(invocation -> {
+                            AssistantContentSimpleConsumers consumers = invocation.getArgument(2);
+                            simulateTextResponse(consumers, "What this authorizes: Agent can search.");
+                            return null;
+                        });
+
+                OperationTextRenderResult result = renderer.render(context);
+
+                assertThat(result.getSemanticExpansionLevel()).isEqualTo(SemanticExpansionLevel.HIGH);
+            }
+        }
+
+        @Test
+        @DisplayName("Should return MEDIUM expansion level when original prompt is present")
+        void shouldReturnMediumExpansionWhenOriginalPromptPresent() {
+            QwenLlmOperationTextRenderer renderer = new QwenLlmOperationTextRenderer(TEST_MODEL, TEST_TIMEOUT);
+
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .operationProposal("package agent\nallow { input.action == \"search\" }")
+                    .originalPrompt("Find books about Java")
+                    .build();
+
+            try (MockedStatic<QwenCodeCli> mockedCli = mockStatic(QwenCodeCli.class)) {
+                mockedCli.when(() -> QwenCodeCli.simpleQuery(
+                        anyString(), any(TransportOptions.class), any(AssistantContentSimpleConsumers.class)))
+                        .thenAnswer(invocation -> {
+                            AssistantContentSimpleConsumers consumers = invocation.getArgument(2);
+                            simulateTextResponse(consumers, "Rendered text");
+                            return null;
+                        });
+
+                OperationTextRenderResult result = renderer.render(context);
+
+                assertThat(result.getSemanticExpansionLevel()).isEqualTo(SemanticExpansionLevel.MEDIUM);
+            }
+        }
+
+        @Test
+        @DisplayName("Should return HIGH expansion level when original prompt is empty")
+        void shouldReturnHighExpansionWhenOriginalPromptEmpty() {
+            QwenLlmOperationTextRenderer renderer = new QwenLlmOperationTextRenderer(TEST_MODEL, TEST_TIMEOUT);
+
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .operationProposal("package agent\nallow { true }")
+                    .originalPrompt("")
+                    .build();
+
+            try (MockedStatic<QwenCodeCli> mockedCli = mockStatic(QwenCodeCli.class)) {
+                mockedCli.when(() -> QwenCodeCli.simpleQuery(
+                        anyString(), any(TransportOptions.class), any(AssistantContentSimpleConsumers.class)))
+                        .thenAnswer(invocation -> {
+                            AssistantContentSimpleConsumers consumers = invocation.getArgument(2);
+                            simulateTextResponse(consumers, "Rendered text");
+                            return null;
+                        });
+
+                OperationTextRenderResult result = renderer.render(context);
+
+                assertThat(result.getSemanticExpansionLevel()).isEqualTo(SemanticExpansionLevel.HIGH);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("Fallback Tests")
+    class FallbackTests {
+
+        @Test
+        @DisplayName("Should fall back when LLM call throws exception")
+        void shouldFallBackWhenLlmCallThrows() {
+            QwenLlmOperationTextRenderer renderer = new QwenLlmOperationTextRenderer(TEST_MODEL, TEST_TIMEOUT);
+
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .operationProposal("package agent\nallow { input.action == \"search\" }")
+                    .originalPrompt("Search for books")
+                    .build();
+
+            try (MockedStatic<QwenCodeCli> mockedCli = mockStatic(QwenCodeCli.class)) {
+                mockedCli.when(() -> QwenCodeCli.simpleQuery(
+                        anyString(), any(TransportOptions.class), any(AssistantContentSimpleConsumers.class)))
+                        .thenThrow(new RuntimeException("Network error"));
+
+                OperationTextRenderResult result = renderer.render(context);
+
+                assertThat(result).isNotNull();
+                assertThat(result.getRenderedText()).isEqualTo("Authorized: Search for books");
+                assertThat(result.getSemanticExpansionLevel()).isEqualTo(SemanticExpansionLevel.LOW);
+            }
+        }
+
+        @Test
+        @DisplayName("Should fall back to operation proposal when LLM fails and no original prompt")
+        void shouldFallBackToOperationProposalWhenNoOriginalPrompt() {
+            QwenLlmOperationTextRenderer renderer = new QwenLlmOperationTextRenderer(TEST_MODEL, TEST_TIMEOUT);
+
+            String shortPolicy = "package agent\nallow { input.action == \"read\" }";
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .operationProposal(shortPolicy)
+                    .build();
+
+            try (MockedStatic<QwenCodeCli> mockedCli = mockStatic(QwenCodeCli.class)) {
+                mockedCli.when(() -> QwenCodeCli.simpleQuery(
+                        anyString(), any(TransportOptions.class), any(AssistantContentSimpleConsumers.class)))
+                        .thenThrow(new RuntimeException("Timeout"));
+
+                OperationTextRenderResult result = renderer.render(context);
+
+                assertThat(result).isNotNull();
+                assertThat(result.getRenderedText()).startsWith("Authorized agent operation per policy:");
+                assertThat(result.getSemanticExpansionLevel()).isEqualTo(SemanticExpansionLevel.LOW);
+            }
+        }
+
+        @Test
+        @DisplayName("Should fall back to generic message when LLM fails and no proposal or prompt")
+        void shouldFallBackToGenericMessageWhenNoProposalOrPrompt() {
+            QwenLlmOperationTextRenderer renderer = new QwenLlmOperationTextRenderer(TEST_MODEL, TEST_TIMEOUT);
+
+            OperationTextRenderContext context = OperationTextRenderContext.builder().build();
+
+            try (MockedStatic<QwenCodeCli> mockedCli = mockStatic(QwenCodeCli.class)) {
+                mockedCli.when(() -> QwenCodeCli.simpleQuery(
+                        anyString(), any(TransportOptions.class), any(AssistantContentSimpleConsumers.class)))
+                        .thenThrow(new RuntimeException("Error"));
+
+                OperationTextRenderResult result = renderer.render(context);
+
+                assertThat(result).isNotNull();
+                assertThat(result.getRenderedText()).isEqualTo("Authorized agent operation");
+                assertThat(result.getSemanticExpansionLevel()).isEqualTo(SemanticExpansionLevel.NONE);
+            }
+        }
+
+        @Test
+        @DisplayName("Should truncate long operation proposal in fallback")
+        void shouldTruncateLongOperationProposalInFallback() {
+            QwenLlmOperationTextRenderer renderer = new QwenLlmOperationTextRenderer(TEST_MODEL, TEST_TIMEOUT);
+
+            String longPolicy = "package agent\n" + "a".repeat(200);
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .operationProposal(longPolicy)
+                    .build();
+
+            try (MockedStatic<QwenCodeCli> mockedCli = mockStatic(QwenCodeCli.class)) {
+                mockedCli.when(() -> QwenCodeCli.simpleQuery(
+                        anyString(), any(TransportOptions.class), any(AssistantContentSimpleConsumers.class)))
+                        .thenThrow(new RuntimeException("Error"));
+
+                OperationTextRenderResult result = renderer.render(context);
+
+                assertThat(result.getRenderedText()).contains("...");
+                assertThat(result.getRenderedText().length()).isLessThan(longPolicy.length());
+            }
+        }
+
+        @Test
+        @DisplayName("Should fall back when LLM returns empty content")
+        void shouldFallBackWhenLlmReturnsEmptyContent() {
+            QwenLlmOperationTextRenderer renderer = new QwenLlmOperationTextRenderer(TEST_MODEL, TEST_TIMEOUT);
+
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .operationProposal("package agent\nallow { true }")
+                    .originalPrompt("Do something")
+                    .build();
+
+            try (MockedStatic<QwenCodeCli> mockedCli = mockStatic(QwenCodeCli.class)) {
+                // Simulate empty response (no text callback invoked)
+                mockedCli.when(() -> QwenCodeCli.simpleQuery(
+                        anyString(), any(TransportOptions.class), any(AssistantContentSimpleConsumers.class)))
+                        .thenAnswer(invocation -> null);
+
+                OperationTextRenderResult result = renderer.render(context);
+
+                assertThat(result).isNotNull();
+                assertThat(result.getRenderedText()).isEqualTo("Authorized: Do something");
+                assertThat(result.getSemanticExpansionLevel()).isEqualTo(SemanticExpansionLevel.LOW);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("Prompt Building Tests")
+    class PromptBuildingTests {
+
+        @Test
+        @DisplayName("Should include operation proposal in prompt sent to LLM")
+        void shouldIncludeOperationProposalInPrompt() {
+            QwenLlmOperationTextRenderer renderer = new QwenLlmOperationTextRenderer(TEST_MODEL, TEST_TIMEOUT);
+
+            String policy = "package shopping\nallow { input.category == \"books\" }";
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .operationProposal(policy)
+                    .originalPrompt("Buy books")
+                    .build();
+
+            try (MockedStatic<QwenCodeCli> mockedCli = mockStatic(QwenCodeCli.class)) {
+                mockedCli.when(() -> QwenCodeCli.simpleQuery(
+                        anyString(), any(TransportOptions.class), any(AssistantContentSimpleConsumers.class)))
+                        .thenAnswer(invocation -> {
+                            String prompt = invocation.getArgument(0);
+                            assertThat(prompt).contains("Rego Policy:");
+                            assertThat(prompt).contains(policy);
+                            assertThat(prompt).contains("Buy books");
+
+                            AssistantContentSimpleConsumers consumers = invocation.getArgument(2);
+                            simulateTextResponse(consumers, "Rendered");
+                            return null;
+                        });
+
+                renderer.render(context);
+            }
+        }
+
+        @Test
+        @DisplayName("Should include request context in prompt when available")
+        void shouldIncludeRequestContextInPrompt() {
+            QwenLlmOperationTextRenderer renderer = new QwenLlmOperationTextRenderer(TEST_MODEL, TEST_TIMEOUT);
+
+            OperationRequestContext.AgentContext agentContext = OperationRequestContext.AgentContext.builder()
+                    .platform("web")
+                    .client("test-client")
+                    .build();
+
+            OperationRequestContext requestContext = OperationRequestContext.builder()
+                    .channel("web")
+                    .language("en-US")
+                    .agent(agentContext)
+                    .build();
+
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .operationProposal("package agent\nallow { true }")
+                    .requestContext(requestContext)
+                    .build();
+
+            try (MockedStatic<QwenCodeCli> mockedCli = mockStatic(QwenCodeCli.class)) {
+                mockedCli.when(() -> QwenCodeCli.simpleQuery(
+                        anyString(), any(TransportOptions.class), any(AssistantContentSimpleConsumers.class)))
+                        .thenAnswer(invocation -> {
+                            String prompt = invocation.getArgument(0);
+                            assertThat(prompt).contains("Channel: web");
+                            assertThat(prompt).contains("Language: en-US");
+                            assertThat(prompt).contains("Platform: web");
+                            assertThat(prompt).contains("Client: test-client");
+
+                            AssistantContentSimpleConsumers consumers = invocation.getArgument(2);
+                            simulateTextResponse(consumers, "Rendered");
+                            return null;
+                        });
+
+                renderer.render(context);
+            }
+        }
+
+        @Test
+        @DisplayName("Should include token expiration in prompt when available")
+        void shouldIncludeTokenExpirationInPrompt() {
+            QwenLlmOperationTextRenderer renderer = new QwenLlmOperationTextRenderer(TEST_MODEL, TEST_TIMEOUT);
+
+            java.time.Instant expiration = java.time.Instant.parse("2026-12-31T23:59:59Z");
+            OperationTextRenderContext context = OperationTextRenderContext.builder()
+                    .operationProposal("package agent\nallow { true }")
+                    .tokenExpiration(expiration)
+                    .build();
+
+            try (MockedStatic<QwenCodeCli> mockedCli = mockStatic(QwenCodeCli.class)) {
+                mockedCli.when(() -> QwenCodeCli.simpleQuery(
+                        anyString(), any(TransportOptions.class), any(AssistantContentSimpleConsumers.class)))
+                        .thenAnswer(invocation -> {
+                            String prompt = invocation.getArgument(0);
+                            assertThat(prompt).contains("Authorization valid until:");
+
+                            AssistantContentSimpleConsumers consumers = invocation.getArgument(2);
+                            simulateTextResponse(consumers, "Rendered");
+                            return null;
+                        });
+
+                renderer.render(context);
+            }
+        }
+
+        @Test
+        @DisplayName("Should handle context with null fields gracefully")
+        void shouldHandleContextWithNullFieldsGracefully() {
+            QwenLlmOperationTextRenderer renderer = new QwenLlmOperationTextRenderer(TEST_MODEL, TEST_TIMEOUT);
+
+            OperationTextRenderContext context = OperationTextRenderContext.builder().build();
+
+            try (MockedStatic<QwenCodeCli> mockedCli = mockStatic(QwenCodeCli.class)) {
+                mockedCli.when(() -> QwenCodeCli.simpleQuery(
+                        anyString(), any(TransportOptions.class), any(AssistantContentSimpleConsumers.class)))
+                        .thenAnswer(invocation -> {
+                            String prompt = invocation.getArgument(0);
+                            assertThat(prompt).doesNotContain("Rego Policy:");
+                            assertThat(prompt).doesNotContain("User's Original Request:");
+
+                            AssistantContentSimpleConsumers consumers = invocation.getArgument(2);
+                            simulateTextResponse(consumers, "Generic authorization");
+                            return null;
+                        });
+
+                OperationTextRenderResult result = renderer.render(context);
+                assertThat(result.getRenderedText()).isEqualTo("Generic authorization");
+            }
+        }
+    }
+
+    /**
+     * Simulates a text response from the Qwen model by invoking the onText callback
+     * with a mock TextAssistantContent.
+     */
+    private void simulateTextResponse(AssistantContentSimpleConsumers consumers, String text) {
+        com.alibaba.qwen.code.cli.protocol.data.AssistantContent.TextAssistantContent textContent =
+                org.mockito.Mockito.mock(
+                        com.alibaba.qwen.code.cli.protocol.data.AssistantContent.TextAssistantContent.class);
+        org.mockito.Mockito.when(textContent.getText()).thenReturn(text);
+        consumers.onText(null, textContent);
+    }
+}

--- a/open-agent-auth-spring-boot-starter/src/main/java/com/alibaba/openagentauth/spring/autoconfigure/role/AuthorizationServerAutoConfiguration.java
+++ b/open-agent-auth-spring-boot-starter/src/main/java/com/alibaba/openagentauth/spring/autoconfigure/role/AuthorizationServerAutoConfiguration.java
@@ -665,9 +665,11 @@ public class AuthorizationServerAutoConfiguration {
 
         @Bean
         @ConditionalOnMissingBean
-        public ConsentPageProvider consentPageProvider(PromptDecryptionService promptDecryptionService) {
+        public ConsentPageProvider consentPageProvider(PromptDecryptionService promptDecryptionService,
+                                                       OperationTextRenderer operationTextRenderer) {
             logger.info("Creating ConsentPageProvider bean with DefaultConsentPageProvider for Authorization Server");
-            return new DefaultConsentPageProvider(CONSENT_TEMPLATE_AOA, "Authorization Server", promptDecryptionService);
+            return new DefaultConsentPageProvider(CONSENT_TEMPLATE_AOA, "Authorization Server",
+                    promptDecryptionService, operationTextRenderer);
         }
     }
 }

--- a/open-agent-auth-spring-boot-starter/src/main/java/com/alibaba/openagentauth/spring/web/provider/DefaultConsentPageProvider.java
+++ b/open-agent-auth-spring-boot-starter/src/main/java/com/alibaba/openagentauth/spring/web/provider/DefaultConsentPageProvider.java
@@ -15,6 +15,9 @@
  */
 package com.alibaba.openagentauth.spring.web.provider;
 
+import com.alibaba.openagentauth.core.audit.api.OperationTextRenderer;
+import com.alibaba.openagentauth.core.audit.model.OperationTextRenderContext;
+import com.alibaba.openagentauth.core.audit.model.OperationTextRenderResult;
 import com.alibaba.openagentauth.core.model.context.OperationRequestContext;
 import com.alibaba.openagentauth.core.model.evidence.Evidence;
 import com.alibaba.openagentauth.core.model.evidence.VerifiableCredential;
@@ -26,6 +29,7 @@ import com.alibaba.openagentauth.framework.web.provider.ConsentPageProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.lang.Nullable;
 import org.springframework.web.servlet.ModelAndView;
 
 import java.time.Instant;
@@ -96,10 +100,21 @@ public class DefaultConsentPageProvider implements ConsentPageProvider {
     private final PromptDecryptionService promptDecryptionService;
 
     /**
+     * Optional renderer for generating human-readable operation text from agent operation proposals.
+     * <p>
+     * When configured, the consent page will display a rendered natural-language description
+     * of the operation policy alongside the raw Rego policy. This follows the AOA protocol's
+     * {@code renderedText} field requirement in the {@code context} and {@code auditTrail} claims.
+     * </p>
+     */
+    @Nullable
+    private final OperationTextRenderer operationTextRenderer;
+
+    /**
      * Creates a new DefaultConsentPageProvider with default view name.
      */
     public DefaultConsentPageProvider() {
-        this(DEFAULT_VIEW_NAME, "Identity Provider", null);
+        this(DEFAULT_VIEW_NAME, "Identity Provider", null, null);
     }
 
     /**
@@ -108,7 +123,7 @@ public class DefaultConsentPageProvider implements ConsentPageProvider {
      * @param viewName the Thymeleaf template view name
      */
     public DefaultConsentPageProvider(String viewName) {
-        this(viewName, "Identity Provider", null);
+        this(viewName, "Identity Provider", null, null);
     }
 
     /**
@@ -118,7 +133,7 @@ public class DefaultConsentPageProvider implements ConsentPageProvider {
      * @param displayName the display name for the IDP
      */
     public DefaultConsentPageProvider(String viewName, String displayName) {
-        this(viewName, displayName, null);
+        this(viewName, displayName, null, null);
     }
 
     /**
@@ -131,9 +146,24 @@ public class DefaultConsentPageProvider implements ConsentPageProvider {
      */
     public DefaultConsentPageProvider(String viewName, String displayName,
                                       PromptDecryptionService promptDecryptionService) {
+        this(viewName, displayName, promptDecryptionService, null);
+    }
+
+    /**
+     * Creates a new DefaultConsentPageProvider with all configurable dependencies.
+     *
+     * @param viewName the Thymeleaf template view name
+     * @param displayName the display name for the IDP
+     * @param promptDecryptionService the service for decrypting JWE-encrypted prompts (nullable)
+     * @param operationTextRenderer the renderer for generating human-readable operation text (nullable)
+     */
+    public DefaultConsentPageProvider(String viewName, String displayName,
+                                      PromptDecryptionService promptDecryptionService,
+                                      @Nullable OperationTextRenderer operationTextRenderer) {
         this.viewName = viewName;
         this.displayName = displayName;
         this.promptDecryptionService = promptDecryptionService;
+        this.operationTextRenderer = operationTextRenderer;
     }
 
     @Override
@@ -198,6 +228,9 @@ public class DefaultConsentPageProvider implements ConsentPageProvider {
                 mv.addObject("context", context);
             }
 
+            // Render human-readable operation text using the configured renderer
+            renderAndAddOperationText(mv, parClaims);
+
             AgentUserBindingProposal bindingProposal = parClaims.getAgentUserBindingProposal();
             if (bindingProposal != null) {
                 mv.addObject("agentUserBindingProposal", bindingProposal);
@@ -217,6 +250,59 @@ public class DefaultConsentPageProvider implements ConsentPageProvider {
 
         logger.info("User consent action: {}, approved: {}", action, approved);
         return approved;
+    }
+
+    /**
+     * Renders human-readable operation text from the PAR claims and adds it to the model.
+     * <p>
+     * According to draft-liu-agent-operation-authorization-01 Section 4, the Authorization Server
+     * generates a {@code renderedText} that describes the authorized operation in a human-readable
+     * format. This method uses the configured {@link OperationTextRenderer} to produce that text
+     * for display on the consent page.
+     * </p>
+     * <p>
+     * The following model attributes are added when rendering succeeds:
+     * </p>
+     * <ul>
+     *   <li>{@code renderedOperationText} — the human-readable description</li>
+     *   <li>{@code semanticExpansionLevel} — the level of semantic interpretation applied</li>
+     * </ul>
+     *
+     * @param modelAndView the ModelAndView to add rendered text to
+     * @param parClaims the PAR JWT claims containing the operation proposal and context
+     */
+    private void renderAndAddOperationText(ModelAndView modelAndView, ParJwtClaims parClaims) {
+
+        if (operationTextRenderer == null) {
+            logger.debug("No OperationTextRenderer configured, skipping operation text rendering");
+            return;
+        }
+
+        try {
+            // Retrieve the already-decoded original user prompt from the model (if available)
+            String originalPrompt = null;
+            if (modelAndView.getModel().containsKey("originalUserPrompt")) {
+                originalPrompt = (String) modelAndView.getModel().get("originalUserPrompt");
+            }
+
+            OperationTextRenderContext renderContext = OperationTextRenderContext.builder()
+                    .operationProposal(parClaims.getOperationProposal())
+                    .originalPrompt(originalPrompt)
+                    .requestContext(parClaims.getContext())
+                    .build();
+
+            OperationTextRenderResult renderResult = operationTextRenderer.render(renderContext);
+
+            modelAndView.addObject("renderedOperationText", renderResult.getRenderedText());
+            modelAndView.addObject("semanticExpansionLevel",
+                    renderResult.getSemanticExpansionLevel().getValue());
+
+            logger.info("Successfully rendered operation text: '{}' (expansion: {})",
+                    renderResult.getRenderedText(), renderResult.getSemanticExpansionLevel());
+        } catch (Exception e) {
+            logger.warn("Failed to render operation text, consent page will show raw policy only. Error: {}",
+                    e.getMessage());
+        }
     }
 
     /**

--- a/open-agent-auth-spring-boot-starter/src/main/resources/templates/oauth2/aoa_consent.html
+++ b/open-agent-auth-spring-boot-starter/src/main/resources/templates/oauth2/aoa_consent.html
@@ -211,7 +211,7 @@
         .info-value {
             color: var(--color-text-primary);
             font-size: var(--font-size-sm);
-            font-weight: var(--font-weight-medium);
+            font-weight: 400;
             word-break: break-word;
         }
 
@@ -378,7 +378,7 @@
         .user-prompt-text {
             color: var(--color-text-primary);
             font-size: var(--font-size-base);
-            font-weight: var(--font-weight-medium);
+            font-weight: 400;
             line-height: 1.7;
             font-style: italic;
             padding-left: var(--space-4);
@@ -415,7 +415,7 @@
             border-radius: var(--radius-full);
             font-size: var(--font-size-xs);
             color: var(--color-text-secondary);
-            font-weight: var(--font-weight-medium);
+            font-weight: 400;
             transition: all var(--transition-fast);
         }
 
@@ -497,6 +497,45 @@
         .collapsible-header.active .arrow {
             transform: rotate(180deg);
             color: var(--color-primary);
+        }
+
+        .rendered-operation-block {
+            position: relative;
+            padding: var(--space-4) var(--space-5);
+            background: linear-gradient(135deg, rgba(184, 134, 11, 0.06), rgba(184, 134, 11, 0.02) 60%);
+            border: 1px solid var(--color-border-primary);
+            border-radius: var(--radius-md);
+        }
+
+        .rendered-operation-text {
+            color: var(--color-text-primary);
+            font-size: var(--font-size-sm);
+            font-weight: 400;
+            line-height: 1.7;
+            white-space: pre-line;
+        }
+
+        .rendered-operation-meta {
+            display: flex;
+            align-items: center;
+            gap: var(--space-2);
+            margin-top: var(--space-3);
+            padding-top: var(--space-3);
+            border-top: 1px solid rgba(184, 134, 11, 0.12);
+        }
+
+        .expansion-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            background: var(--color-primary-bg);
+            color: var(--color-primary-dark);
+            border: 1px solid rgba(184, 134, 11, 0.2);
+            padding: 2px 10px;
+            border-radius: var(--radius-full);
+            font-size: 11px;
+            font-weight: var(--font-weight-medium);
+            letter-spacing: 0.3px;
         }
 
         .warning-box {
@@ -680,10 +719,10 @@
                 </div>
                 
                 <div class="warning-box" style="background: rgba(255, 215, 0, 0.05); border-color: rgba(255, 215, 0, 0.2);">
-                    <i class="bi bi-shield-exclamation"></i>
+                    <i class="bi bi-shield-check"></i>
                     <div>
-                        <strong>Security Notice</strong><br>
-                        <span style="font-size: 12px;">Only approve if you trust this application</span>
+                        <strong>Verify Origin</strong><br>
+                        <span style="font-size: 12px;">Confirm you recognize this application before proceeding.</span>
                     </div>
                 </div>
                 
@@ -703,7 +742,28 @@
                         <div class="auth-section-title">
                             <i class="bi bi-gear"></i> Operation Policy
                         </div>
-                        <div class="code-block" th:text="${parClaims.operationProposal}">operation proposal</div>
+                        
+                        <!-- Rendered natural-language description (when available) -->
+                        <div th:if="${renderedOperationText != null}" class="rendered-operation-block">
+                            <div class="rendered-operation-text" th:text="${renderedOperationText}">
+                                Purchase items under $50 during the Nov 11 promotion (valid until 23:59)
+                            </div>
+                            <div class="rendered-operation-meta" th:if="${semanticExpansionLevel != null}">
+                                <span class="expansion-badge" th:text="'Interpretation: ' + ${semanticExpansionLevel}">Interpretation: medium</span>
+                            </div>
+                        </div>
+                        
+                        <!-- Raw Rego policy: collapsible when rendered text is available, direct otherwise -->
+                        <div th:if="${renderedOperationText != null}" class="collapsible" style="margin-top: var(--space-3);">
+                            <div class="collapsible-header" onclick="toggleCollapse(this)">
+                                <span><i class="bi bi-code-square"></i> Raw Policy (Rego)</span>
+                                <span class="arrow"><i class="bi bi-chevron-down"></i></span>
+                            </div>
+                            <div class="collapsible-content">
+                                <div class="code-block" th:text="${parClaims.operationProposal}">operation proposal</div>
+                            </div>
+                        </div>
+                        <div th:if="${renderedOperationText == null}" class="code-block" th:text="${parClaims.operationProposal}">operation proposal</div>
                     </div>
                     
                     <div class="auth-section" th:if="${parClaims.evidence != null and parClaims.evidence.sourcePromptCredential != null}">
@@ -837,9 +897,9 @@
                 </div>
                 
                 <div class="warning-box" style="margin-top: auto;">
-                    <i class="bi bi-exclamation-triangle"></i>
+                    <i class="bi bi-info-circle"></i>
                     <div>
-                        <strong>Security Notice:</strong> This authorization grants the application access to perform agent operations on your behalf. Only approve if you trust the application.
+                        By approving, the agent may act on your behalf within the scope described above. You can revoke this authorization at any time.
                     </div>
                 </div>
                 

--- a/open-agent-auth-spring-boot-starter/src/test/java/com/alibaba/openagentauth/spring/web/provider/DefaultConsentPageProviderTest.java
+++ b/open-agent-auth-spring-boot-starter/src/test/java/com/alibaba/openagentauth/spring/web/provider/DefaultConsentPageProviderTest.java
@@ -15,6 +15,10 @@
  */
 package com.alibaba.openagentauth.spring.web.provider;
 
+import com.alibaba.openagentauth.core.audit.api.OperationTextRenderer;
+import com.alibaba.openagentauth.core.audit.model.OperationTextRenderContext;
+import com.alibaba.openagentauth.core.audit.model.OperationTextRenderResult;
+import com.alibaba.openagentauth.core.audit.model.SemanticExpansionLevel;
 import com.alibaba.openagentauth.core.crypto.jwe.JweDecoder;
 import com.alibaba.openagentauth.core.model.context.OperationRequestContext;
 import com.alibaba.openagentauth.core.model.evidence.Evidence;
@@ -61,6 +65,9 @@ class DefaultConsentPageProviderTest {
     @Mock
     private JweDecoder jweDecoder;
 
+    @Mock
+    private OperationTextRenderer operationTextRenderer;
+
     private PromptDecryptionService promptDecryptionService;
 
     private DefaultConsentPageProvider provider;
@@ -105,6 +112,26 @@ class DefaultConsentPageProviderTest {
                 new DefaultConsentPageProvider("consent", "Test IDP", null);
 
             assertThat(providerWithNull).isNotNull();
+        }
+
+        @Test
+        @DisplayName("Should create provider with OperationTextRenderer")
+        void shouldCreateProviderWithOperationTextRenderer() {
+            DefaultConsentPageProvider providerWithRenderer =
+                new DefaultConsentPageProvider("consent", "Test IDP",
+                        promptDecryptionService, operationTextRenderer);
+
+            assertThat(providerWithRenderer).isNotNull();
+        }
+
+        @Test
+        @DisplayName("Should create provider with null OperationTextRenderer")
+        void shouldCreateProviderWithNullOperationTextRenderer() {
+            DefaultConsentPageProvider providerWithNullRenderer =
+                new DefaultConsentPageProvider("consent", "Test IDP",
+                        promptDecryptionService, null);
+
+            assertThat(providerWithNullRenderer).isNotNull();
         }
     }
 
@@ -415,6 +442,165 @@ class DefaultConsentPageProviderTest {
 
             assertThat(mv.getModel()).doesNotContainKey("decodedCredential");
             assertThat(mv.getModel()).doesNotContainKey("originalUserPrompt");
+        }
+    }
+
+    @Nested
+    @DisplayName("Operation Text Rendering Tests")
+    class OperationTextRenderingTests {
+
+        @Test
+        @DisplayName("Should add rendered operation text when renderer is configured")
+        void shouldAddRenderedOperationTextWhenRendererConfigured() {
+            DefaultConsentPageProvider providerWithRenderer =
+                new DefaultConsentPageProvider("consent", "Test IDP", null, operationTextRenderer);
+
+            OperationTextRenderResult renderResult = new OperationTextRenderResult(
+                    "The agent can search for programming books.", SemanticExpansionLevel.MEDIUM);
+            when(operationTextRenderer.render(any(OperationTextRenderContext.class)))
+                    .thenReturn(renderResult);
+
+            ParJwtClaims parClaims = createTestParClaims();
+
+            ModelAndView mv = providerWithRenderer.renderConsentPage(
+                    request, "urn:req:1", "user1", "client1", "openid", parClaims);
+
+            assertThat(mv.getModel()).containsEntry("renderedOperationText",
+                    "The agent can search for programming books.");
+            assertThat(mv.getModel()).containsEntry("semanticExpansionLevel", "medium");
+        }
+
+        @Test
+        @DisplayName("Should not add rendered text when renderer is null")
+        void shouldNotAddRenderedTextWhenRendererIsNull() {
+            DefaultConsentPageProvider providerWithoutRenderer =
+                new DefaultConsentPageProvider("consent", "Test IDP", null, null);
+
+            ParJwtClaims parClaims = createTestParClaims();
+
+            ModelAndView mv = providerWithoutRenderer.renderConsentPage(
+                    request, "urn:req:1", "user1", "client1", "openid", parClaims);
+
+            assertThat(mv.getModel()).doesNotContainKey("renderedOperationText");
+            assertThat(mv.getModel()).doesNotContainKey("semanticExpansionLevel");
+        }
+
+        @Test
+        @DisplayName("Should handle renderer exception gracefully")
+        void shouldHandleRendererExceptionGracefully() {
+            DefaultConsentPageProvider providerWithRenderer =
+                new DefaultConsentPageProvider("consent", "Test IDP", null, operationTextRenderer);
+
+            when(operationTextRenderer.render(any(OperationTextRenderContext.class)))
+                    .thenThrow(new RuntimeException("LLM call failed"));
+
+            ParJwtClaims parClaims = createTestParClaims();
+
+            ModelAndView mv = providerWithRenderer.renderConsentPage(
+                    request, "urn:req:1", "user1", "client1", "openid", parClaims);
+
+            assertThat(mv).isNotNull();
+            assertThat(mv.getModel()).doesNotContainKey("renderedOperationText");
+            assertThat(mv.getModel()).doesNotContainKey("semanticExpansionLevel");
+        }
+
+        @Test
+        @DisplayName("Should pass operation proposal to render context")
+        void shouldPassOperationProposalToRenderContext() {
+            DefaultConsentPageProvider providerWithRenderer =
+                new DefaultConsentPageProvider("consent", "Test IDP", null, operationTextRenderer);
+
+            OperationTextRenderResult renderResult = new OperationTextRenderResult(
+                    "Rendered text", SemanticExpansionLevel.LOW);
+            when(operationTextRenderer.render(any(OperationTextRenderContext.class)))
+                    .thenReturn(renderResult);
+
+            ParJwtClaims parClaims = createTestParClaims();
+
+            providerWithRenderer.renderConsentPage(
+                    request, "urn:req:1", "user1", "client1", "openid", parClaims);
+
+            verify(operationTextRenderer).render(argThat(context ->
+                    context.getOperationProposal() != null
+                    && context.getOperationProposal().contains("input.operationType")));
+        }
+
+        @Test
+        @DisplayName("Should pass request context to render context")
+        void shouldPassRequestContextToRenderContext() {
+            DefaultConsentPageProvider providerWithRenderer =
+                new DefaultConsentPageProvider("consent", "Test IDP", null, operationTextRenderer);
+
+            OperationTextRenderResult renderResult = new OperationTextRenderResult(
+                    "Rendered text", SemanticExpansionLevel.MEDIUM);
+            when(operationTextRenderer.render(any(OperationTextRenderContext.class)))
+                    .thenReturn(renderResult);
+
+            ParJwtClaims parClaims = createTestParClaims();
+
+            providerWithRenderer.renderConsentPage(
+                    request, "urn:req:1", "user1", "client1", "openid", parClaims);
+
+            verify(operationTextRenderer).render(argThat(context ->
+                    context.getRequestContext() != null
+                    && "web".equals(context.getRequestContext().getChannel())));
+        }
+
+        @Test
+        @DisplayName("Should not call renderer when PAR claims are null")
+        void shouldNotCallRendererWhenParClaimsAreNull() {
+            DefaultConsentPageProvider providerWithRenderer =
+                new DefaultConsentPageProvider("consent", "Test IDP", null, operationTextRenderer);
+
+            ModelAndView mv = providerWithRenderer.renderConsentPage(
+                    request, "urn:req:1", "user1", "client1", "openid", null);
+
+            verifyNoInteractions(operationTextRenderer);
+            assertThat(mv.getModel()).doesNotContainKey("renderedOperationText");
+        }
+
+        @Test
+        @DisplayName("Should pass decoded user prompt to render context when available")
+        void shouldPassDecodedUserPromptToRenderContextWhenAvailable() {
+            DefaultConsentPageProvider providerWithRenderer =
+                new DefaultConsentPageProvider("consent", "Test IDP", null, operationTextRenderer);
+
+            OperationTextRenderResult renderResult = new OperationTextRenderResult(
+                    "Rendered text", SemanticExpansionLevel.MEDIUM);
+            when(operationTextRenderer.render(any(OperationTextRenderContext.class)))
+                    .thenReturn(renderResult);
+
+            String testJwtVc = createTestJwtVcString();
+            Evidence evidence = Evidence.builder()
+                    .sourcePromptCredential(testJwtVc)
+                    .build();
+            ParJwtClaims parClaims = createTestParClaims(evidence);
+
+            providerWithRenderer.renderConsentPage(
+                    request, "urn:req:1", "user1", "client1", "openid", parClaims);
+
+            verify(operationTextRenderer).render(argThat(context ->
+                    "Test user prompt".equals(context.getOriginalPrompt())));
+        }
+
+        @Test
+        @DisplayName("Should render with HIGH expansion level")
+        void shouldRenderWithHighExpansionLevel() {
+            DefaultConsentPageProvider providerWithRenderer =
+                new DefaultConsentPageProvider("consent", "Test IDP", null, operationTextRenderer);
+
+            OperationTextRenderResult renderResult = new OperationTextRenderResult(
+                    "High expansion text", SemanticExpansionLevel.HIGH);
+            when(operationTextRenderer.render(any(OperationTextRenderContext.class)))
+                    .thenReturn(renderResult);
+
+            ParJwtClaims parClaims = createTestParClaims();
+
+            ModelAndView mv = providerWithRenderer.renderConsentPage(
+                    request, "urn:req:1", "user1", "client1", "openid", parClaims);
+
+            assertThat(mv.getModel()).containsEntry("renderedOperationText", "High expansion text");
+            assertThat(mv.getModel()).containsEntry("semanticExpansionLevel", "high");
         }
     }
 


### PR DESCRIPTION
## Description

Add LLM-based operation text rendering to the AOA consent page and improve consent page UX. When enabled, the consent page displays a human-readable natural-language description of the Rego policy (generated by Qwen LLM) alongside the raw policy, with a semantic expansion level badge. The consent page visual hierarchy and security notice sections are also refined.

## Type of Change
- [x] New feature
- [x] Code refactoring
- [x] Test additions or updates
- [x] Other (Consent page UX improvement)

## Changes Made

### 1. LLM-based Operation Text Renderer (`sample-authorization-server`)
- **New `QwenLlmOperationTextRenderer`**: Implements `OperationTextRenderer` using `qwencode-sdk` (`QwenCodeCli.simpleQuery`) to translate Rego policies into concise three-part descriptions ("What this authorizes" / "Key constraints" / "What this means for you")
- **New `LlmRendererConfiguration`**: Spring `@Configuration` with `@ConditionalOnProperty(name = "sample.llm-renderer.enabled")`, creates the renderer bean with configurable model name and timeout
- **New `application.yml` config**: `sample.llm-renderer.enabled=true`, `model=qwen3-coder-flash`, `timeout=120`
- **New `pom.xml` dependency**: `qwencode-sdk:0.0.1-alpha`

### 2. Consent Page Provider Integration (`open-agent-auth-spring-boot-starter`)
- **`DefaultConsentPageProvider`**: Added optional `OperationTextRenderer` field (nullable), new 4-parameter constructor, and `renderAndAddOperationText()` method that builds `OperationTextRenderContext` from PAR claims and adds `renderedOperationText` + `semanticExpansionLevel` to the Thymeleaf model
- **`AuthorizationServerAutoConfiguration`**: Updated `consentPageProvider` bean to inject `OperationTextRenderer`

### 3. Consent Page Template UX (`aoa_consent.html`)
- **Rendered operation text block**: New `.rendered-operation-block` with `.rendered-operation-text` and `.expansion-badge` for displaying LLM-generated descriptions
- **Collapsible raw policy**: When rendered text is available, the raw Rego policy is shown in a collapsible section; otherwise displayed directly
- **Font-weight reduction**: `.info-value`, `.user-prompt-text`, `.expansion-badge` changed from `font-weight: 500` to `400` for better information hierarchy
- **Security notice differentiation**: Sidebar notice changed to "Verify Origin" (`bi-shield-check`); pre-action notice changed to a concise authorization impact statement (`bi-info-circle`)

### 4. Unit Tests
- **`DefaultConsentPageProviderTest`** (+8 tests): Covers `OperationTextRenderer` integration — constructor variants, render success with MEDIUM/HIGH expansion levels, null renderer, renderer exception handling, operation proposal/request context/user prompt forwarding, null PAR claims
- **`QwenLlmOperationTextRendererTest`** (15 tests, new): Covers constructor validation, LLM render success, expansion level determination (MEDIUM vs HIGH), fallback on LLM failure/empty response/timeout, prompt building with policy/context/token expiration, null field handling
- **`LlmRendererConfigurationTest`** (3 tests, new): Covers bean creation with default/custom model name and timeout

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test Instructions:**
```bash
# DefaultConsentPageProvider tests (includes OperationTextRenderer integration)
mvn test -pl open-agent-auth-spring-boot-starter \
  -Dtest="DefaultConsentPageProviderTest" \
  -DfailIfNoTests=false -Djacoco.skip=true

# QwenLlmOperationTextRenderer & LlmRendererConfiguration tests
mvn test -pl open-agent-auth-samples/sample-authorization-server \
  -Dtest="QwenLlmOperationTextRendererTest,LlmRendererConfigurationTest" \
  -DfailIfNoTests=false -Djacoco.skip=true

# All related unit tests
mvn test -pl open-agent-auth-spring-boot-starter,open-agent-auth-samples/sample-authorization-server \
  -Dtest="DefaultConsentPageProviderTest,QwenLlmOperationTextRendererTest,LlmRendererConfigurationTest" \
  -DfailIfNoTests=false -Djacoco.skip=true
```

## Checklist
- [x] Code follows [coding standards](CONTRIBUTING.md#coding-standards)
- [x] Self-review performed
- [x] No new warnings
- [x] Tests added/updated
- [x] All tests pass locally

## Breaking Changes
No breaking changes.
- The `DefaultConsentPageProvider` constructor chain is backward-compatible (existing 1/2/3-parameter constructors delegate to the new 4-parameter constructor with `null` renderer)
- The consent page template changes are purely additive (rendered text block only appears when `renderedOperationText` model attribute is present)
- The LLM renderer is sample-module-only and gated by `sample.llm-renderer.enabled` property
